### PR TITLE
fix: accept normalized groundedness evidence spans

### DIFF
--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -290,7 +290,11 @@ def _normalized_text_with_offsets(text: str) -> tuple[str, list[int]]:
 
 
 def _verbatim_span(raw_span: str, row_text: str) -> str | None:
-    normalized_span, _ = _normalized_text_with_offsets(raw_span.strip())
+    raw_span = raw_span.strip()
+    if raw_span and raw_span in row_text:
+        return raw_span
+
+    normalized_span, _ = _normalized_text_with_offsets(raw_span)
     normalized_row, offsets = _normalized_text_with_offsets(row_text)
     start = normalized_row.find(normalized_span) if normalized_span else -1
     if start < 0:

--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -270,6 +270,34 @@ class FactualityJudge(LLMJudgeScorer):
         return super().score(output=output, input=input, context=context, **kwargs)
 
 
+_QUOTE_NORMALIZATION = str.maketrans("‘’‚‛“”„‟", "''''\"\"\"\"")
+
+
+def _normalized_text_with_offsets(text: str) -> tuple[str, list[int]]:
+    normalized: list[str] = []
+    offsets: list[int] = []
+    in_whitespace = False
+    for index, char in enumerate(text):
+        if char.isspace():
+            if in_whitespace:
+                continue
+            char = " "
+        normalized.append(char.translate(_QUOTE_NORMALIZATION))
+        offsets.append(index)
+        in_whitespace = char == " "
+    offsets.append(len(text))
+    return "".join(normalized), offsets
+
+
+def _verbatim_span(raw_span: str, row_text: str) -> str | None:
+    normalized_span, _ = _normalized_text_with_offsets(raw_span.strip())
+    normalized_row, offsets = _normalized_text_with_offsets(row_text)
+    start = normalized_row.find(normalized_span) if normalized_span else -1
+    if start < 0:
+        return None
+    return row_text[offsets[start] : offsets[start + len(normalized_span)]]
+
+
 def _verified_evidence_spans(
     raw_spans: Any,
     *,
@@ -288,14 +316,9 @@ def _verified_evidence_spans(
         context_span = item.get("context_span")
         if not isinstance(response_span, str) or not isinstance(context_span, str):
             continue
-        response_span = response_span.strip()
-        context_span = context_span.strip()
-        if (
-            response_span
-            and context_span
-            and response_span in output
-            and context_span in context
-        ):
+        response_span = _verbatim_span(response_span, output)
+        context_span = _verbatim_span(context_span, context)
+        if response_span and context_span:
             verified.append(
                 {"response_span": response_span, "context_span": context_span}
             )

--- a/tests/test_groundedness_scorer.py
+++ b/tests/test_groundedness_scorer.py
@@ -5,7 +5,6 @@
 from unittest.mock import Mock
 
 from rai_toolkit.scorers import GroundednessScorer
-from rai_toolkit.scorers.llm_judges import _verified_evidence_spans
 
 
 def _scorer(result: dict[str, object]) -> GroundednessScorer:
@@ -55,12 +54,26 @@ def test_supported_response_carries_verified_spans() -> None:
 
 
 def test_normalized_evidence_spans_preserve_verbatim_row_text() -> None:
-    spans = [{"response_span": 'The "answer" is 42.', "context_span": "It's correct."}]
-    assert _verified_evidence_spans(
-        spans,
-        output="The “answer”\n  is 42.",
+    scorer = _scorer(
+        {
+            "score": 3,
+            "supporting_spans": [
+                {
+                    "response_span": 'The "answer" is 42.',
+                    "context_span": "It's correct.",
+                }
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "The “answer”\n  is 42.",
         context="The source says: It’s\tcorrect.",
-    ) == [{"response_span": "The “answer”\n  is 42.", "context_span": "It’s\tcorrect."}]
+    )
+
+    assert result.details["supporting_spans"] == [
+        {"response_span": "The “answer”\n  is 42.", "context_span": "It’s\tcorrect."}
+    ]
 
 
 def test_fabricated_evidence_spans_are_discarded() -> None:

--- a/tests/test_groundedness_scorer.py
+++ b/tests/test_groundedness_scorer.py
@@ -5,6 +5,7 @@
 from unittest.mock import Mock
 
 from rai_toolkit.scorers import GroundednessScorer
+from rai_toolkit.scorers.llm_judges import _verified_evidence_spans
 
 
 def _scorer(result: dict[str, object]) -> GroundednessScorer:
@@ -51,6 +52,15 @@ def test_supported_response_carries_verified_spans() -> None:
             "context_span": "Revenue grew by 12% year over year.",
         }
     ]
+
+
+def test_normalized_evidence_spans_preserve_verbatim_row_text() -> None:
+    spans = [{"response_span": 'The "answer" is 42.', "context_span": "It's correct."}]
+    assert _verified_evidence_spans(
+        spans,
+        output="The “answer”\n  is 42.",
+        context="The source says: It’s\tcorrect.",
+    ) == [{"response_span": "The “answer”\n  is 42.", "context_span": "It’s\tcorrect."}]
 
 
 def test_fabricated_evidence_spans_are_discarded() -> None:


### PR DESCRIPTION
Fixes #16

## Summary

- Normalize internal whitespace and typographic quotes before verifying judge evidence spans.
- Map normalized matches back to original row offsets so stored evidence remains verbatim.

## Tests

- `.venv/bin/python -m pytest -q` — 4 passed
- `ruff check rai_toolkit/scorers/llm_judges.py tests/test_groundedness_scorer.py` — passed
