### PR TITLE
fix(scorers): match evidence spans through judge-side normalization

### DIFF
--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -270,6 +270,61 @@ class FactualityJudge(LLMJudgeScorer):
         return super().score(output=output, input=input, context=context, **kwargs)
 
 
+_QUOTE_EQUIVALENTS = {
+    "‘": "'",
+    "’": "'",
+    "“": '"',
+    "”": '"',
+}
+
+
+def _normalized_chars(text: str) -> tuple[str, list[int]]:
+    """Normalize for matching: collapse whitespace runs, unify quote characters.
+
+    Returns the normalized text together with a map from each normalized
+    character back to its index in the original text, so a match found in
+    normalized space can be sliced verbatim from the original.
+    """
+
+    chars: list[str] = []
+    positions: list[int] = []
+    space_pending = False
+    for index, char in enumerate(text):
+        if char.isspace():
+            # Leading whitespace is dropped; interior runs collapse to one space
+            space_pending = bool(chars)
+            continue
+        if space_pending:
+            chars.append(" ")
+            positions.append(index)
+            space_pending = False
+        chars.append(_QUOTE_EQUIVALENTS.get(char, char))
+        positions.append(index)
+    return "".join(chars), positions
+
+
+def _find_verbatim_span(span: str, row_text: str) -> str | None:
+    """Locate ``span`` in ``row_text``, tolerating judge-side normalization.
+
+    Judge models often collapse whitespace or emit curly quotes, which must not
+    discard otherwise-legitimate evidence. The match is searched in normalized
+    space, but the returned span is always sliced from ``row_text`` itself, so
+    stored evidence stays verbatim row text rather than the judge's version.
+    """
+
+    if span in row_text:
+        return span
+    normalized_span, _ = _normalized_chars(span)
+    if not normalized_span:
+        return None
+    normalized_row, positions = _normalized_chars(row_text)
+    start = normalized_row.find(normalized_span)
+    if start == -1:
+        return None
+    end = start + len(normalized_span) - 1
+    return row_text[positions[start] : positions[end] + 1]
+
+
 def _verified_evidence_spans(
     raw_spans: Any,
     *,
@@ -290,14 +345,13 @@ def _verified_evidence_spans(
             continue
         response_span = response_span.strip()
         context_span = context_span.strip()
-        if (
-            response_span
-            and context_span
-            and response_span in output
-            and context_span in context
-        ):
+        if not response_span or not context_span:
+            continue
+        verbatim_response = _find_verbatim_span(response_span, output)
+        verbatim_context = _find_verbatim_span(context_span, context)
+        if verbatim_response is not None and verbatim_context is not None:
             verified.append(
-                {"response_span": response_span, "context_span": context_span}
+                {"response_span": verbatim_response, "context_span": verbatim_context}
             )
     return verified
 

--- a/tests/test_groundedness_scorer.py
+++ b/tests/test_groundedness_scorer.py
@@ -53,6 +53,63 @@ def test_supported_response_carries_verified_spans() -> None:
     ]
 
 
+def test_judge_normalized_whitespace_does_not_discard_spans() -> None:
+    context = "Revenue grew by 12%\n    year over year."
+    scorer = _scorer(
+        {
+            "score": 3,
+            "explanation": "Supported.",
+            "supporting_spans": [
+                {
+                    "response_span": "Revenue grew 12%.",
+                    # Judge collapsed the newline and indentation to one space
+                    "context_span": "Revenue grew by 12% year over year.",
+                }
+            ],
+            "contradicting_spans": [],
+        }
+    )
+
+    result = scorer.score("Revenue grew 12%.", context=context)
+
+    # The stored span is verbatim row text, not the judge's normalized version
+    assert result.details["supporting_spans"] == [
+        {
+            "response_span": "Revenue grew 12%.",
+            "context_span": "Revenue grew by 12%\n    year over year.",
+        }
+    ]
+    assert result.details["discarded_evidence_spans"] == 0
+
+
+def test_judge_straightened_quotes_do_not_discard_spans() -> None:
+    context = "The vendor said “no refunds” after day 30."
+    scorer = _scorer(
+        {
+            "score": 3,
+            "explanation": "Supported.",
+            "supporting_spans": [
+                {
+                    "response_span": "No refunds after day 30.",
+                    # Judge emitted straight quotes for the row's curly ones
+                    "context_span": 'The vendor said "no refunds" after day 30.',
+                }
+            ],
+            "contradicting_spans": [],
+        }
+    )
+
+    result = scorer.score("No refunds after day 30.", context=context)
+
+    assert result.details["supporting_spans"] == [
+        {
+            "response_span": "No refunds after day 30.",
+            "context_span": "The vendor said “no refunds” after day 30.",
+        }
+    ]
+    assert result.details["discarded_evidence_spans"] == 0
+
+
 def test_fabricated_evidence_spans_are_discarded() -> None:
     scorer = _scorer(
         {


### PR DESCRIPTION
Closes #16

`_verified_evidence_spans` required exact substring membership, so spans the judge lightly normalized — collapsed whitespace, straightened quotes — were discarded and inflated `discarded_evidence_spans`.

**Approach** (as proposed in the issue):

- `_normalized_chars` collapses whitespace runs to a single space and unifies curly/straight quote characters, returning the normalized text **plus an index map back to the original**.
- `_find_verbatim_span` keeps the exact-substring fast path; on miss it searches in normalized space and slices the match **from the original row text**, so stored evidence remains verbatim row text, never the judge's version.
- Discarding stays the failure direction: spans that don't match even after normalization are still dropped, and fabricated spans are unaffected.

**Tests:** two new cases — a context span with a collapsed newline+indentation run, and straight-vs-curly quotes — both asserting the *stored* span is the original row text and `discarded_evidence_spans == 0`. Existing tests unchanged and passing (5/5).