### PR TITLE
fix(scorers): preserve default LLM judge categories

### DIFF
--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -96,7 +96,7 @@ class LLMJudgeScorer(BaseScorer):
         base_url: str | None = None,
         temperature: float = 0.1,
         threshold: float = 0.5,
-        category: str = "",
+        category: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(category=category, threshold=threshold, **kwargs)

--- a/tests/test_llm_judge_categories.py
+++ b/tests/test_llm_judge_categories.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Yusef Syed
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+from rai_toolkit.scorers import FactualityJudge
+
+
+def test_llm_judge_preserves_class_category_by_default() -> None:
+    scorer = FactualityJudge(api_key="test")
+
+    assert scorer.category == "MIT-3.1"
+
+
+def test_llm_judge_accepts_explicit_category_override() -> None:
+    scorer = FactualityJudge(api_key="test", category="custom")
+
+    assert scorer.category == "custom"
+
+
+def test_llm_judge_accepts_explicit_empty_category_override() -> None:
+    scorer = FactualityJudge(api_key="test", category="")
+
+    assert scorer.category == ""


### PR DESCRIPTION
## Summary

- let `BaseScorer` retain an LLM judge subclass's declared category when construction does not supply an override
- preserve both non-empty and explicit empty-string category overrides
- add focused regression coverage for all three constructor paths

Fixes #28.

## Why

`LLMJudgeScorer.__init__` previously defaulted `category` to `""` and always passed that value to `BaseScorer`. Because `BaseScorer` uses `None` to mean “keep the class attribute,” direct construction replaced categories such as `FactualityJudge.category == "MIT-3.1"` with an empty string.

Changing the default to `None` uses the existing sentinel contract. Callers that explicitly pass a category—including `category=""`—retain the previous override behavior.

## Validation

- `uv run --extra dev pytest tests/test_llm_judge_categories.py -q` — 3 passed
- `uv run --extra dev pytest tests/test_groundedness_scorer.py -q` — 6 passed
- `uv run --extra dev pytest -q` — 9 passed
- `uv run python -m compileall -q rai_toolkit tests` — passed
- `uvx --from 'reuse[charset-normalizer]' reuse lint` — REUSE 3.3 compliant

The existing test run reports 11 `asyncio.iscoroutinefunction` deprecation warnings from `rai_toolkit/_tracing.py`; this change does not introduce or modify them.

## AI assistance disclosure

AI tools assisted with repository search, implementation drafting, and an independent fresh-context review. I directed the work, reproduced the bug on the pinned upstream revision, reviewed the source and final two-file diff, added the compatibility edge case raised during review, and ran the validation listed above.
