### PR TITLE
fix: preserve additional scorers in Weave assessments

### DIFF
--- a/integrations/weave_integration/scorers.py
+++ b/integrations/weave_integration/scorers.py
@@ -6,12 +6,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 import weave
 
 from rai_toolkit.scorers.base import BaseScorer, ScorerResult
+from rai_toolkit.scorers.llm_judges import LLMJudgeScorer
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +65,15 @@ def _filter_inner_scorer_kwargs(scorer: BaseScorer, extras: dict[str, Any]) -> d
     if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
         return dict(extras)
     return {k: v for k, v in extras.items() if k in sig.parameters}
+
+
+def _score_async_delegates_to_sync(scorer: BaseScorer) -> bool:
+    """Return whether score_async directly delegates to blocking score."""
+    implementation = type(scorer).score_async
+    return implementation in {
+        BaseScorer.score_async,
+        LLMJudgeScorer.score_async,
+    }
 
 
 class WeaveRAIScorer(weave.Scorer):
@@ -159,13 +170,24 @@ class WeaveRAIScorer(weave.Scorer):
         if plain_rubrics is not None:
             optional_inputs["rubrics"] = plain_rubrics
 
-        result = await self._rai_scorer.score_async(
-            output=output_text,
-            input=input_text,
-            context=effective_context,
-            **_filter_inner_scorer_kwargs(self._rai_scorer, optional_inputs),
-            **kwargs,
-        )
+        scorer_extras = _filter_inner_scorer_kwargs(self._rai_scorer, optional_inputs)
+        if _score_async_delegates_to_sync(self._rai_scorer):
+            result = await asyncio.to_thread(
+                self._rai_scorer.score,
+                output=output_text,
+                input=input_text,
+                context=effective_context,
+                **scorer_extras,
+                **kwargs,
+            )
+        else:
+            result = await self._rai_scorer.score_async(
+                output=output_text,
+                input=input_text,
+                context=effective_context,
+                **scorer_extras,
+                **kwargs,
+            )
 
         # Serialize manually instead of ``asdict`` so we can coerce
         # WeaveList/WeaveDict anywhere they sneak into ``details``

--- a/integrations/weave_integration/scorers.py
+++ b/integrations/weave_integration/scorers.py
@@ -109,7 +109,7 @@ class WeaveRAIScorer(weave.Scorer):
         call_display_name=lambda call: _wrapped_scorer_display_name(call),
         kind="scorer",
     )
-    def score(
+    async def score(
         self,
         output: dict[str, Any] | str,
         input_text: str = "",
@@ -159,7 +159,7 @@ class WeaveRAIScorer(weave.Scorer):
         if plain_rubrics is not None:
             optional_inputs["rubrics"] = plain_rubrics
 
-        result = self._rai_scorer.score(
+        result = await self._rai_scorer.score_async(
             output=output_text,
             input=input_text,
             context=effective_context,

--- a/rai_toolkit/assessment/assessor.py
+++ b/rai_toolkit/assessment/assessor.py
@@ -533,15 +533,7 @@ class Assessor:
 
                 weave_additional_scorers = []
                 for scorer in self.additional_scorers:
-                    try:
-                        weave_additional_scorers.append(make_weave_rai_scorer(scorer))
-                    except Exception as e:  # noqa: BLE001 - keep valid scorers running
-                        logger.warning(
-                            "Could not adapt additional scorer %s for Weave; "
-                            "skipping it (%s).",
-                            type(scorer).__name__,
-                            e,
-                        )
+                    weave_additional_scorers.append(make_weave_rai_scorer(scorer))
 
                 weave_ds = _dataset_rows_for_weave(dataset)
                 weave_model = WeaveModel(rai_model=self.model, model_name=self.model.name)

--- a/rai_toolkit/assessment/assessor.py
+++ b/rai_toolkit/assessment/assessor.py
@@ -520,11 +520,28 @@ class Assessor:
 
         if self._should_use_weave_evaluation():
             try:
-                from integrations.weave_integration.evaluation import WeaveEvaluationRunner
+                from integrations.weave_integration.evaluation import (
+                    WeaveEvaluationRunner,
+                )
+                from integrations.weave_integration.models import WeaveModel
+                from integrations.weave_integration.scorers import (
+                    make_weave_rai_scorer,
+                )
                 from rai_toolkit.evaluation.weave_adapter import (
                     weave_eval_results_to_evaluation_results,
                 )
-                from integrations.weave_integration.models import WeaveModel
+
+                weave_additional_scorers = []
+                for scorer in self.additional_scorers:
+                    try:
+                        weave_additional_scorers.append(make_weave_rai_scorer(scorer))
+                    except Exception as e:  # noqa: BLE001 - keep valid scorers running
+                        logger.warning(
+                            "Could not adapt additional scorer %s for Weave; "
+                            "skipping it (%s).",
+                            type(scorer).__name__,
+                            e,
+                        )
 
                 weave_ds = _dataset_rows_for_weave(dataset)
                 weave_model = WeaveModel(rai_model=self.model, model_name=self.model.name)
@@ -536,6 +553,7 @@ class Assessor:
                     weave_ds,
                     name=ev_name,
                     include_weave_builtins=self.include_weave_builtin_scorers,
+                    additional_scorers=weave_additional_scorers,
                 )
                 return weave_eval_results_to_evaluation_results(
                     self.pipeline,

--- a/tests/test_assessment_weave_additional_scorers.py
+++ b/tests/test_assessment_weave_additional_scorers.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import logging
 import sys
+from collections.abc import Callable
+from dataclasses import dataclass
 from types import ModuleType
 from typing import Any
 
@@ -42,10 +44,15 @@ class StubScorer(BaseScorer):
         )
 
 
+@dataclass
+class FakeWeaveRAIScorer:
+    rai_scorer: BaseScorer
+
+
 def _install_fake_weave_modules(
     monkeypatch: pytest.MonkeyPatch,
     *,
-    adapter: Any,
+    adapter: Callable[[BaseScorer], FakeWeaveRAIScorer],
     captured: dict[str, Any],
     expected_result: object,
 ) -> None:
@@ -63,9 +70,19 @@ def _install_fake_weave_modules(
             model: object,
             profile: object,
             dataset: object,
-            **kwargs: Any,
+            *,
+            name: str,
+            include_weave_builtins: bool,
+            additional_scorers: list[FakeWeaveRAIScorer],
         ) -> tuple[object, dict[str, Any]]:
-            captured.update(kwargs)
+            assert all(
+                isinstance(scorer, FakeWeaveRAIScorer) for scorer in additional_scorers
+            )
+            captured.update(
+                name=name,
+                include_weave_builtins=include_weave_builtins,
+                additional_scorers=additional_scorers,
+            )
             return object(), {}
 
     evaluation_module.WeaveEvaluationRunner = FakeWeaveEvaluationRunner  # type: ignore[attr-defined]
@@ -107,12 +124,14 @@ async def test_weave_evaluation_receives_adapted_additional_scorers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     scorer = StubScorer()
-    adapted_scorer = object()
+    adapted_scorer = FakeWeaveRAIScorer(scorer)
     captured: dict[str, Any] = {}
     expected_result = object()
     _install_fake_weave_modules(
         monkeypatch,
-        adapter=lambda value: adapted_scorer if value is scorer else None,
+        adapter=lambda value: (
+            adapted_scorer if value is scorer else FakeWeaveRAIScorer(value)
+        ),
         captured=captured,
         expected_result=expected_result,
     )
@@ -133,26 +152,26 @@ async def test_weave_evaluation_receives_adapted_additional_scorers(
 
 
 @pytest.mark.asyncio
-async def test_weave_evaluation_warns_and_keeps_adaptable_scorers(
+async def test_weave_evaluation_falls_back_to_core_pipeline_when_adaptation_fails(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     adaptable = StubScorer(name="adaptable")
     unsupported = StubScorer(name="unsupported")
-    adapted_scorer = object()
     captured: dict[str, Any] = {}
-    expected_result = object()
+    weave_result = object()
+    fallback_result = object()
 
-    def adapt(scorer: StubScorer) -> object:
+    def adapt(scorer: BaseScorer) -> FakeWeaveRAIScorer:
         if scorer is unsupported:
             raise TypeError("unsupported scorer")
-        return adapted_scorer
+        return FakeWeaveRAIScorer(scorer)
 
     _install_fake_weave_modules(
         monkeypatch,
         adapter=adapt,
         captured=captured,
-        expected_result=expected_result,
+        expected_result=weave_result,
     )
     assessor = Assessor(
         model=StubModel(),
@@ -163,9 +182,22 @@ async def test_weave_evaluation_warns_and_keeps_adaptable_scorers(
     monkeypatch.setattr(assessor, "_should_use_weave_evaluation", lambda: True)
     profile = assessor.engine.create_profile_from_preset("general")
 
+    async def run_core_evaluation(**kwargs: Any) -> object:
+        captured["core_kwargs"] = kwargs
+        return fallback_result
+
+    monkeypatch.setattr(assessor.pipeline, "run_evaluation", run_core_evaluation)
+
     with caplog.at_level(logging.WARNING):
         result = await assessor._run_evaluation(profile, [{"input": "hello"}])
 
-    assert result is expected_result
-    assert captured["additional_scorers"] == [adapted_scorer]
-    assert "Could not adapt additional scorer StubScorer for Weave" in caplog.text
+    assert result is fallback_result
+    assert captured["core_kwargs"]["model"] is assessor.model
+    assert captured["core_kwargs"]["profile"] is profile
+    assert captured["core_kwargs"]["dataset"] == [{"input": "hello"}]
+    assert assessor.pipeline.additional_scorers == [adaptable, unsupported]
+    assert "additional_scorers" not in captured
+    assert (
+        "Weave-native evaluation unavailable (unsupported scorer); using core pipeline."
+        in caplog.text
+    )

--- a/tests/test_assessment_weave_additional_scorers.py
+++ b/tests/test_assessment_weave_additional_scorers.py
@@ -44,6 +44,43 @@ class StubScorer(BaseScorer):
         )
 
 
+class AsyncContractScorer(BaseScorer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sync_calls = 0
+        self.async_calls = 0
+
+    def score(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: Any,
+    ) -> ScorerResult:
+        self.sync_calls += 1
+        return ScorerResult(
+            score=0.0,
+            passed=False,
+            category="custom",
+            explanation="sync",
+        )
+
+    async def score_async(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: Any,
+    ) -> ScorerResult:
+        self.async_calls += 1
+        return ScorerResult(
+            score=1.0,
+            passed=True,
+            category="custom",
+            explanation="async",
+        )
+
+
 @dataclass
 class FakeWeaveRAIScorer:
     rai_scorer: BaseScorer
@@ -201,3 +238,59 @@ async def test_weave_evaluation_falls_back_to_core_pipeline_when_adaptation_fail
         "Weave-native evaluation unavailable (unsupported scorer); using core pipeline."
         in caplog.text
     )
+
+
+@pytest.mark.asyncio
+async def test_real_weave_evaluation_awaits_async_additional_scorer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("weave")
+    from rai_toolkit.compliance.frameworks import ComplianceProfile, Framework
+
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("WANDB_SILENT", "true")
+
+    profile = ComplianceProfile(
+        name="empty",
+        framework=Framework.MIT_AI_RISK,
+        categories=[],
+    )
+    dataset = [{"input": "hello"}]
+
+    weave_scorer = AsyncContractScorer()
+    weave_assessor = Assessor(
+        model=StubModel(),
+        preset="general",
+        datasets=["unused"],
+        additional_scorers=[weave_scorer],
+        use_weave_evaluation=True,
+        include_weave_builtin_scorers=False,
+    )
+    weave_result = await weave_assessor._run_evaluation(profile, dataset)
+
+    core_scorer = AsyncContractScorer()
+    core_assessor = Assessor(
+        model=StubModel(),
+        preset="general",
+        datasets=["unused"],
+        additional_scorers=[core_scorer],
+        use_weave_evaluation=False,
+    )
+    core_result = await core_assessor._run_evaluation(profile, dataset)
+
+    scorer_name = "AsyncContractScorer"
+    assert weave_result.metadata["evaluation_backend"] == "weave"
+    assert weave_result.metadata["scorers_used"] == [scorer_name]
+    assert set(weave_result.items[0].scores) == {scorer_name}
+    assert set(core_result.items[0].scores) == {scorer_name}
+    weave_cell = weave_result.items[0].scores[scorer_name]
+    core_cell = core_result.items[0].scores[scorer_name]
+
+    assert weave_scorer.sync_calls == 0
+    assert weave_scorer.async_calls == 1
+    assert core_scorer.sync_calls == 0
+    assert core_scorer.async_calls == 1
+    assert weave_cell == core_cell
+    assert weave_cell.score == 1.0
+    assert weave_cell.passed is True
+    assert weave_cell.explanation == "async"

--- a/tests/test_assessment_weave_additional_scorers.py
+++ b/tests/test_assessment_weave_additional_scorers.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: 2026 Yusef Syed
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+from __future__ import annotations
+
+import logging
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from rai_toolkit.assessment import Assessor
+from rai_toolkit.models.base import BaseModel, ModelResponse
+from rai_toolkit.scorers.base import BaseScorer, ScorerResult
+
+
+class StubModel(BaseModel):
+    async def predict(
+        self,
+        input_text: str,
+        context: str = "",
+        **kwargs: Any,
+    ) -> ModelResponse:
+        return ModelResponse(output="stub")
+
+
+class StubScorer(BaseScorer):
+    def score(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: Any,
+    ) -> ScorerResult:
+        return ScorerResult(
+            score=1.0,
+            passed=True,
+            category="custom",
+            explanation="stub",
+        )
+
+
+def _install_fake_weave_modules(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    adapter: Any,
+    captured: dict[str, Any],
+    expected_result: object,
+) -> None:
+    weave_package = ModuleType("integrations.weave_integration")
+    weave_package.__path__ = []  # type: ignore[attr-defined]
+
+    evaluation_module = ModuleType("integrations.weave_integration.evaluation")
+
+    class FakeWeaveEvaluationRunner:
+        def __init__(self, engine: object) -> None:
+            self.engine = engine
+
+        async def get_detailed_evaluation(
+            self,
+            model: object,
+            profile: object,
+            dataset: object,
+            **kwargs: Any,
+        ) -> tuple[object, dict[str, Any]]:
+            captured.update(kwargs)
+            return object(), {}
+
+    evaluation_module.WeaveEvaluationRunner = FakeWeaveEvaluationRunner  # type: ignore[attr-defined]
+
+    scorers_module = ModuleType("integrations.weave_integration.scorers")
+    scorers_module.make_weave_rai_scorer = adapter  # type: ignore[attr-defined]
+
+    models_module = ModuleType("integrations.weave_integration.models")
+    models_module.WeaveModel = lambda **kwargs: object()  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "integrations.weave_integration", weave_package)
+    monkeypatch.setitem(
+        sys.modules,
+        "integrations.weave_integration.evaluation",
+        evaluation_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "integrations.weave_integration.scorers",
+        scorers_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "integrations.weave_integration.models",
+        models_module,
+    )
+
+    from rai_toolkit.evaluation import weave_adapter
+
+    monkeypatch.setattr(
+        weave_adapter,
+        "weave_eval_results_to_evaluation_results",
+        lambda *args, **kwargs: expected_result,
+    )
+
+
+@pytest.mark.asyncio
+async def test_weave_evaluation_receives_adapted_additional_scorers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scorer = StubScorer()
+    adapted_scorer = object()
+    captured: dict[str, Any] = {}
+    expected_result = object()
+    _install_fake_weave_modules(
+        monkeypatch,
+        adapter=lambda value: adapted_scorer if value is scorer else None,
+        captured=captured,
+        expected_result=expected_result,
+    )
+
+    assessor = Assessor(
+        model=StubModel(),
+        preset="general",
+        datasets=["unused"],
+        additional_scorers=[scorer],
+    )
+    monkeypatch.setattr(assessor, "_should_use_weave_evaluation", lambda: True)
+    profile = assessor.engine.create_profile_from_preset("general")
+
+    result = await assessor._run_evaluation(profile, [{"input": "hello"}])
+
+    assert result is expected_result
+    assert captured["additional_scorers"] == [adapted_scorer]
+
+
+@pytest.mark.asyncio
+async def test_weave_evaluation_warns_and_keeps_adaptable_scorers(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    adaptable = StubScorer(name="adaptable")
+    unsupported = StubScorer(name="unsupported")
+    adapted_scorer = object()
+    captured: dict[str, Any] = {}
+    expected_result = object()
+
+    def adapt(scorer: StubScorer) -> object:
+        if scorer is unsupported:
+            raise TypeError("unsupported scorer")
+        return adapted_scorer
+
+    _install_fake_weave_modules(
+        monkeypatch,
+        adapter=adapt,
+        captured=captured,
+        expected_result=expected_result,
+    )
+    assessor = Assessor(
+        model=StubModel(),
+        preset="general",
+        datasets=["unused"],
+        additional_scorers=[adaptable, unsupported],
+    )
+    monkeypatch.setattr(assessor, "_should_use_weave_evaluation", lambda: True)
+    profile = assessor.engine.create_profile_from_preset("general")
+
+    with caplog.at_level(logging.WARNING):
+        result = await assessor._run_evaluation(profile, [{"input": "hello"}])
+
+    assert result is expected_result
+    assert captured["additional_scorers"] == [adapted_scorer]
+    assert "Could not adapt additional scorer StubScorer for Weave" in caplog.text

--- a/tests/test_assessment_weave_additional_scorers.py
+++ b/tests/test_assessment_weave_additional_scorers.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import logging
 import sys
+import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from types import ModuleType
@@ -16,6 +18,7 @@ import pytest
 from rai_toolkit.assessment import Assessor
 from rai_toolkit.models.base import BaseModel, ModelResponse
 from rai_toolkit.scorers.base import BaseScorer, ScorerResult
+from rai_toolkit.scorers.llm_judges import LLMJudgeScorer
 
 
 class StubModel(BaseModel):
@@ -46,7 +49,7 @@ class StubScorer(BaseScorer):
 
 class AsyncContractScorer(BaseScorer):
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(name="async_contract")
         self.sync_calls = 0
         self.async_calls = 0
 
@@ -79,6 +82,62 @@ class AsyncContractScorer(BaseScorer):
             category="custom",
             explanation="async",
         )
+
+
+class BlockingSyncScorer(BaseScorer):
+    def __init__(self) -> None:
+        super().__init__(name="blocking_sync")
+        self._lock = threading.Lock()
+        self.active_calls = 0
+        self.max_active_calls = 0
+        self.total_calls = 0
+
+    def score(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: Any,
+    ) -> ScorerResult:
+        with self._lock:
+            self.active_calls += 1
+            self.total_calls += 1
+            self.max_active_calls = max(self.max_active_calls, self.active_calls)
+        try:
+            time.sleep(0.05)
+        finally:
+            with self._lock:
+                self.active_calls -= 1
+        return ScorerResult(
+            score=1.0,
+            passed=True,
+            category="custom",
+            explanation="blocking sync",
+        )
+
+
+class BlockingLLMJudgeScorer(LLMJudgeScorer):
+    name = "blocking_llm_judge"
+    _judge_name = "FactualityJudge"
+
+    def __init__(self) -> None:
+        super().__init__(api_key="test")
+        self._lock = threading.Lock()
+        self.active_calls = 0
+        self.max_active_calls = 0
+        self.total_calls = 0
+
+    def _call_judge(self, system_prompt: str, user_prompt: str) -> dict[str, Any]:
+        with self._lock:
+            self.active_calls += 1
+            self.total_calls += 1
+            self.max_active_calls = max(self.max_active_calls, self.active_calls)
+        try:
+            time.sleep(0.05)
+        finally:
+            with self._lock:
+                self.active_calls -= 1
+        return {"score": 3, "explanation": "blocking llm judge"}
 
 
 @dataclass
@@ -278,7 +337,7 @@ async def test_real_weave_evaluation_awaits_async_additional_scorer(
     )
     core_result = await core_assessor._run_evaluation(profile, dataset)
 
-    scorer_name = "AsyncContractScorer"
+    scorer_name = "async_contract"
     assert weave_result.metadata["evaluation_backend"] == "weave"
     assert weave_result.metadata["scorers_used"] == [scorer_name]
     assert set(weave_result.items[0].scores) == {scorer_name}
@@ -294,3 +353,47 @@ async def test_real_weave_evaluation_awaits_async_additional_scorer(
     assert weave_cell.score == 1.0
     assert weave_cell.passed is True
     assert weave_cell.explanation == "async"
+
+
+@pytest.mark.asyncio
+async def test_real_weave_evaluation_keeps_sync_scorers_concurrent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("weave")
+    from rai_toolkit.compliance.frameworks import ComplianceProfile, Framework
+
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("WANDB_SILENT", "true")
+
+    profile = ComplianceProfile(
+        name="empty",
+        framework=Framework.MIT_AI_RISK,
+        categories=[],
+    )
+    dataset = [{"input": f"hello {index}"} for index in range(12)]
+    sync_scorer = BlockingSyncScorer()
+    llm_scorer = BlockingLLMJudgeScorer()
+    assessor = Assessor(
+        model=StubModel(),
+        preset="general",
+        datasets=["unused"],
+        additional_scorers=[sync_scorer, llm_scorer],
+        use_weave_evaluation=True,
+        include_weave_builtin_scorers=False,
+    )
+
+    result = await assessor._run_evaluation(profile, dataset)
+
+    scorer_names = {"blocking_sync", "blocking_llm_judge"}
+    assert result.metadata["evaluation_backend"] == "weave"
+    assert set(result.metadata["scorers_used"]) == scorer_names
+    assert len(result.items) == len(dataset)
+    for item in result.items:
+        assert set(item.scores) == scorer_names
+        assert all(cell.score == 1.0 for cell in item.scores.values())
+        assert all(cell.passed for cell in item.scores.values())
+
+    for scorer in (sync_scorer, llm_scorer):
+        assert scorer.total_calls == len(dataset)
+        assert scorer.active_calls == 0
+        assert scorer.max_active_calls > 1


### PR DESCRIPTION
Closes #29.

## Summary

- adapt caller-supplied toolkit scorers with the existing Weave scorer adapter
- forward the adapted scorers into `get_detailed_evaluation`
- preserve the documented `BaseScorer.score_async()` extension point in the Weave wrapper
- move inherited synchronous scorers and the bundled LLM judge bridge to worker threads so Weave retains row and scorer concurrency
- fall back to the core pipeline with every requested scorer if adaptation or Weave execution fails

## Verification

- the real offline Weave regression reproduces the pre-fix divergence: Weave called only the sync method and returned 0/fail while core called only the async method and returned 1/pass
- after the fix, the real Assessor, adapter, runner, Weave evaluation, and result converter use the Weave backend, call only the async method, preserve the exact scorer name and result cell, and match the core 1/pass result
- a 12-row real-Weave concurrency regression verifies overlapping calls for both the inherited base sync path and the LLM judge sync bridge while preserving every final result cell
- core environment without Weave: 20 passed, 3 optional tests skipped
- environment with Weave 0.53.7: 25 passed
- focused Ruff check and format check pass for the changed test module
- REUSE lint passes for all 106 files
- `git diff --check` passes for the scoped changes

## Base

The branch is rebased onto current `main` at `b3e81c3`, which includes merged #33 and its configured-scorer-name regression.

AI assistance was used to implement, test, and review this contribution.
