### PR TITLE
fix(weave): use rai_scorer.name instead of class name in WeaveRAIScorer

### DIFF
--- a/integrations/weave_integration/scorers.py
+++ b/integrations/weave_integration/scorers.py
@@ -92,12 +92,12 @@ class WeaveRAIScorer(weave.Scorer):
     _rai_scorer: BaseScorer | None = None
 
     def __init__(self, rai_scorer: BaseScorer, **kwargs: Any) -> None:
-        # Set ``name`` (a weave.Scorer base field) to the rai scorer's class
-        # name so the Evals UI shows e.g. ``FairnessJudge`` in the scorer
-        # column instead of an unhelpful object-ref label. ``name`` also
-        # drives ``Scorer.display_name``.
-        rai_class = type(rai_scorer).__name__
-        kwargs.setdefault("name", rai_class)
+        # Set ``name`` (a weave.Scorer base field) to the rai scorer's
+        # configured ``name`` so that different instances of the same class
+        # (e.g. two rubric scorers with different names) remain distinct in
+        # the Evals UI. Falls back to the class name via BaseScorer when the
+        # scorer has no explicit name set.
+        kwargs.setdefault("name", rai_scorer.name)
         super().__init__(
             rai_scorer_name=rai_scorer.name,
             rai_scorer_category=rai_scorer.category,

--- a/tests/test_weave_rai_scorer_name.py
+++ b/tests/test_weave_rai_scorer_name.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for WeaveRAIScorer name handling.
+
+See https://github.com/wandb/rai-toolkit/issues/32.
+"""
+
+from __future__ import annotations
+
+from rai_toolkit.scorers.base import BaseScorer, ScorerResult
+from integrations.weave_integration.scorers import WeaveRAIScorer
+
+
+class DummyScorer(BaseScorer):
+    """Minimal scorer for testing wrapper name resolution."""
+
+    category = "MIT-1.1"
+
+    def score(self, output: str, input: str = "", context: str = "", **kwargs) -> ScorerResult:
+        return ScorerResult(score=0.5, passed=True, category=self.category, explanation="ok")
+
+
+def test_weave_rai_scorer_uses_configured_name_not_class_name() -> None:
+    """Two instances of the same class with different names must not collide."""
+    alpha = DummyScorer(name="alpha")
+    beta = DummyScorer(name="beta")
+
+    w_alpha = WeaveRAIScorer(rai_scorer=alpha)
+    w_beta = WeaveRAIScorer(rai_scorer=beta)
+
+    assert w_alpha.name == "alpha"
+    assert w_beta.name == "beta"
+    assert w_alpha.name != w_beta.name
+
+
+def test_weave_rai_scorer_falls_back_to_class_name_when_empty() -> None:
+    """When no name is configured, the class name is used (BaseScorer fallback)."""
+    unnamed = DummyScorer()  # name defaults to class name via BaseScorer
+    wrapper = WeaveRAIScorer(rai_scorer=unnamed)
+    assert wrapper.name == "DummyScorer"

--- a/tests/test_weave_rai_scorer_name.py
+++ b/tests/test_weave_rai_scorer_name.py
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-FileCopyrightText: 2026 EffNine
+# SPDX-FileCopyrightText: 2026 Karan Nisar
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
 
 """Regression tests for WeaveRAIScorer name handling.
 
@@ -8,8 +10,11 @@ See https://github.com/wandb/rai-toolkit/issues/32.
 
 from __future__ import annotations
 
+import pytest
+
 from rai_toolkit.scorers.base import BaseScorer, ScorerResult
-from integrations.weave_integration.scorers import WeaveRAIScorer
+
+weave = pytest.importorskip("weave")
 
 
 class DummyScorer(BaseScorer):
@@ -17,12 +22,26 @@ class DummyScorer(BaseScorer):
 
     category = "MIT-1.1"
 
-    def score(self, output: str, input: str = "", context: str = "", **kwargs) -> ScorerResult:
-        return ScorerResult(score=0.5, passed=True, category=self.category, explanation="ok")
+    def score(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: object,
+    ) -> ScorerResult:
+        score = 1.0 if self.name == "alpha" else 0.0
+        return ScorerResult(
+            score=score,
+            passed=bool(score),
+            category=self.category,
+            explanation=self.name,
+        )
 
 
 def test_weave_rai_scorer_uses_configured_name_not_class_name() -> None:
     """Two instances of the same class with different names must not collide."""
+    from integrations.weave_integration.scorers import WeaveRAIScorer
+
     alpha = DummyScorer(name="alpha")
     beta = DummyScorer(name="beta")
 
@@ -36,6 +55,44 @@ def test_weave_rai_scorer_uses_configured_name_not_class_name() -> None:
 
 def test_weave_rai_scorer_falls_back_to_class_name_when_empty() -> None:
     """When no name is configured, the class name is used (BaseScorer fallback)."""
+    from integrations.weave_integration.scorers import WeaveRAIScorer
+
     unnamed = DummyScorer()  # name defaults to class name via BaseScorer
     wrapper = WeaveRAIScorer(rai_scorer=unnamed)
     assert wrapper.name == "DummyScorer"
+
+
+@pytest.mark.asyncio
+async def test_real_weave_evaluation_preserves_both_configured_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Weave must keep both results from differently named instances."""
+    from integrations.weave_integration.scorers import make_weave_rai_scorer
+
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("WANDB_SILENT", "true")
+
+    class StaticWeaveModel(weave.Model):
+        @weave.op()
+        async def predict(self, input_text: str) -> dict[str, str]:
+            return {"output": "response"}
+
+    evaluation = weave.Evaluation(
+        dataset=[{"input_text": "prompt"}],
+        scorers=[
+            make_weave_rai_scorer(DummyScorer(name="alpha")),
+            make_weave_rai_scorer(DummyScorer(name="beta")),
+        ],
+    )
+
+    results = await evaluation.get_eval_results(StaticWeaveModel())
+    row = next(iter(results.rows))
+
+    assert set(row["scores"]) == {"alpha", "beta"}
+    assert row["scores"]["alpha"]["score"] == 1.0
+    assert row["scores"]["beta"]["score"] == 0.0
+
+    summary = await evaluation.summarize(results)
+
+    assert summary["alpha"]["score"]["mean"] == 1.0
+    assert summary["beta"]["score"]["mean"] == 0.0


### PR DESCRIPTION
## Summary

`make_weave_rai_scorer` and `WeaveRAIScorer` name the wrapper from the scorer's **class** name rather than its configured `name`. Two instances of the same class with different names (e.g. two rubric scorers named 'alpha' and 'beta') write to the same Weave key and the later one silently overwrites the earlier:

```
rai_names: alpha beta
score_keys: ['ConfigurableScorer']
scores: {'ConfigurableScorer': {'score': 0.0, 'explanation': 'beta', ...}}
```

## Fix

Change `WeaveRAIScorer.__init__` to use `rai_scorer.name` (which already falls back to the class name via `BaseScorer.__init__`) instead of `type(rai_scorer).__name__`.

## Testing

Added `test_weave_rai_scorer_uses_configured_name_not_class_name` — two differently named instances of one scorer class both appear with their own names.
Added `test_weave_rai_scorer_falls_back_to_class_name_when_empty` — unnamed scorers still default to the class name.

All 20 tests pass.

Closes #32