### PR TITLE
fix(weave): use rai_scorer.name to prevent collisions between instances of same class (#32)

### DIFF
--- a/integrations/weave_integration/scorers.py
+++ b/integrations/weave_integration/scorers.py
@@ -92,12 +92,8 @@ class WeaveRAIScorer(weave.Scorer):
     _rai_scorer: BaseScorer | None = None
 
     def __init__(self, rai_scorer: BaseScorer, **kwargs: Any) -> None:
-        # Set ``name`` (a weave.Scorer base field) to the rai scorer's class
-        # name so the Evals UI shows e.g. ``FairnessJudge`` in the scorer
-        # column instead of an unhelpful object-ref label. ``name`` also
-        # drives ``Scorer.display_name``.
-        rai_class = type(rai_scorer).__name__
-        kwargs.setdefault("name", rai_class)
+        scorer_name = rai_scorer.name or type(rai_scorer).__name__
+        kwargs.setdefault("name", scorer_name)
         super().__init__(
             rai_scorer_name=rai_scorer.name,
             rai_scorer_category=rai_scorer.category,
@@ -209,7 +205,7 @@ def _wrapped_scorer_display_name(call: Any) -> str:
         name = getattr(wrapper, "name", None)
         rai = getattr(wrapper, "_rai_scorer", None)
         if rai is not None:
-            rai_name = type(rai).__name__
+            rai_name = getattr(rai, "name", None) or type(rai).__name__
             category = getattr(rai, "category", None)
             return f"{rai_name} · {category}" if category else rai_name
         if name:
@@ -219,13 +215,19 @@ def _wrapped_scorer_display_name(call: Any) -> str:
         return "scorer"
 
 
-def make_weave_rai_scorer(rai_scorer: BaseScorer) -> WeaveRAIScorer:
+def make_weave_rai_scorer(
+    rai_scorer: BaseScorer,
+    name: str | None = None,
+) -> WeaveRAIScorer:
     """Construct a ``WeaveRAIScorer`` for an rai_toolkit scorer.
 
     Per-call display names come from ``call_display_name`` on the op (see
     :func:`_wrapped_scorer_display_name`); no dynamic subclassing needed.
     """
-    return WeaveRAIScorer(rai_scorer=rai_scorer)
+    kwargs: dict[str, Any] = {}
+    if name is not None:
+        kwargs["name"] = name
+    return WeaveRAIScorer(rai_scorer=rai_scorer, **kwargs)
 
 
 DEFAULT_COLUMN_MAP: dict[str, str] = {

--- a/tests/test_weave_scorers.py
+++ b/tests/test_weave_scorers.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+"""Tests for Weave scorer adapter name handling and collision prevention (issue #32)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from integrations.weave_integration.scorers import (
+    _wrapped_scorer_display_name,
+    make_weave_rai_scorer,
+)
+from rai_toolkit.scorers.base import BaseScorer, ScorerResult
+
+
+class ConfigurableTestScorer(BaseScorer):
+    """Test scorer that returns a score and explanation based on its configuration."""
+
+    def __init__(
+        self, name: str | None = None, score_val: float = 0.8, category: str = "MIT-1.1"
+    ) -> None:
+        super().__init__(name=name, category=category)
+        self.score_val = score_val
+
+    def score(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: Any,
+    ) -> ScorerResult:
+        return ScorerResult(
+            score=self.score_val,
+            passed=self.score_val >= self.threshold,
+            category=self.category,
+            explanation=f"Scored by {self.name}",
+        )
+
+
+def test_two_instances_of_same_scorer_class_have_distinct_names() -> None:
+    """Two instances of the same scorer class must have distinct names on WeaveRAIScorer."""
+    s1 = ConfigurableTestScorer(name="alpha", score_val=0.9)
+    s2 = ConfigurableTestScorer(name="beta", score_val=0.3)
+
+    w1 = make_weave_rai_scorer(s1)
+    w2 = make_weave_rai_scorer(s2)
+
+    assert w1.name == "alpha"
+    assert w2.name == "beta"
+    assert w1.name != w2.name
+
+
+def test_empty_scorer_name_falls_back_to_class_name() -> None:
+    """When an RAI scorer has an empty name, WeaveRAIScorer falls back to the class name."""
+    s = ConfigurableTestScorer(name="")
+    # Manually clear name attribute in case BaseScorer filled it
+    s.name = ""
+
+    w = make_weave_rai_scorer(s)
+    assert w.name == "ConfigurableTestScorer"
+
+
+def test_custom_name_override_in_make_weave_rai_scorer() -> None:
+    """Passing an explicit name to make_weave_rai_scorer overrides the scorer's name."""
+    s = ConfigurableTestScorer(name="default_name")
+    w = make_weave_rai_scorer(s, name="custom_override")
+    assert w.name == "custom_override"
+
+
+def test_wrapped_scorer_display_name_uses_configured_name() -> None:
+    """_wrapped_scorer_display_name formats with the configured scorer name."""
+    s = ConfigurableTestScorer(name="custom_judge", category="MIT-2.1")
+    wrapper = make_weave_rai_scorer(s)
+
+    call_mock = type("Call", (), {"inputs": {"self": wrapper}})()
+    display_name = _wrapped_scorer_display_name(call_mock)
+
+    assert "custom_judge" in display_name
+    assert "MIT-2.1" in display_name
+
+
+def test_two_instances_in_weave_evaluation_do_not_collide() -> None:
+    """Two differently named instances of one scorer class both appear in evaluation results."""
+    s_alpha = ConfigurableTestScorer(name="alpha", score_val=0.95)
+    s_beta = ConfigurableTestScorer(name="beta", score_val=0.25)
+
+    w_alpha = make_weave_rai_scorer(s_alpha)
+    w_beta = make_weave_rai_scorer(s_beta)
+
+    # Evaluate directly with the two wrapped scorers
+    row_output = "Model response text"
+    res_alpha = w_alpha.score(output=row_output)
+    res_beta = w_beta.score(output=row_output)
+
+    assert res_alpha["score"] == 0.95
+    assert res_alpha["explanation"] == "Scored by alpha"
+
+    assert res_beta["score"] == 0.25
+    assert res_beta["explanation"] == "Scored by beta"
+
+    # In Weave evaluations, evaluation scorers are keyed by their .name
+    scorers = [w_alpha, w_beta]
+    scorer_names = [s.name for s in scorers]
+    assert scorer_names == ["alpha", "beta"]
+    assert len(set(scorer_names)) == 2
+
+    # Simulate evaluation aggregation dictionary
+    summary = {s.name: s.score(output=row_output) for s in scorers}
+    assert "alpha" in summary
+    assert "beta" in summary
+    assert summary["alpha"]["score"] == 0.95
+    assert summary["beta"]["score"] == 0.25


### PR DESCRIPTION
Closes #32.

## Problem

`make_weave_rai_scorer` in `integrations/weave_integration/scorers.py` previously named the Weave wrapper from the scorer's class name rather than its configured `name`.

When two instances of the same scorer class (e.g. `ConfigurableScorer(name="alpha")` and `ConfigurableScorer(name="beta")`) were included in an evaluation, both wrappers received `name = "ConfigurableScorer"`. Because Weave keys scorer outputs by `scorer.name`, the second instance overwrote the first in the evaluation summary without error.

## Solution

1. **Use configured scorer name**:
   - In `WeaveRAIScorer.__init__`, set `kwargs.setdefault("name", scorer_name)` where `scorer_name = rai_scorer.name or type(rai_scorer).__name__`.
   - In `make_weave_rai_scorer`, allow an optional `name` override, defaulting to `rai_scorer.name or type(rai_scorer).__name__`.
   - In `_wrapped_scorer_display_name`, format using `getattr(rai, "name", None) or type(rai).__name__`.
2. **Fallback**:
   - If `rai_scorer.name` is falsy, gracefully falls back to `type(rai_scorer).__name__`.

## Tests Added

- `tests/test_weave_scorers.py`:
  - `test_two_instances_of_same_scorer_class_have_distinct_names`: verifies two instances of one class have distinct `.name` attributes matching their configured names.
  - `test_empty_scorer_name_falls_back_to_class_name`: verifies fallback to class name when name is empty.
  - `test_custom_name_override_in_make_weave_rai_scorer`: verifies explicit name override in constructor helper.
  - `test_wrapped_scorer_display_name_uses_configured_name`: verifies call display name includes configured name.
  - `test_two_instances_in_weave_evaluation_do_not_collide`: verifies two differently named instances of one class both execute and produce distinct score entries without collision.

## Verification

- `pytest tests/test_weave_scorers.py` passes (5/5).
- `pytest tests/test_groundedness_scorer.py tests/test_hr_preset.py tests/test_llm_judge_categories.py` passes (18/18).
- `ruff check` passes.
