### PR TITLE
feat(compliance): add NYC Local Law 144 framework mapping

### DIFF
--- a/rai_toolkit/assessment/assessor.py
+++ b/rai_toolkit/assessment/assessor.py
@@ -803,6 +803,33 @@ class Assessor:
         except Exception as e:
             logger.debug("EU AI Act coverage unavailable: %s", e)
 
+        try:
+            from rai_toolkit.compliance.nyc_ll144_mapping import (
+                format_nyc_ll144_framework_label,
+            )
+
+            nyc_cov = self.engine.get_nyc_ll144_coverage(profile)
+            for req_id, cov in nyc_cov.items():
+                assessments.append(
+                    _build_assessment(
+                        framework=format_nyc_ll144_framework_label(
+                            req_id,
+                            section=cov.get("section"),
+                            title=cov.get("title"),
+                        ),
+                        coverage=cov,
+                        eval_results=eval_results,
+                        na_note=(
+                            "No scorer-measurable categories for this requirement. "
+                            "NYC LL 144 obligations (bias audits, notice, publication) "
+                            "are employer-side duties; use this row to track the MIT "
+                            "categories that support them."
+                        ),
+                    )
+                )
+        except Exception as e:
+            logger.debug("NYC LL 144 coverage unavailable: %s", e)
+
         # Framework status reflects each framework's own scorer coverage and the
         # evaluation gate. Red-team hotness and policy hotness are surfaced via
         # their own dedicated verdict gates (red-team severity gate, policy

--- a/rai_toolkit/compliance/engine.py
+++ b/rai_toolkit/compliance/engine.py
@@ -35,6 +35,11 @@ from rai_toolkit.compliance.eu_ai_act_mapping import (
     get_all_required_mit_categories,
     get_mit_categories_for_eu_requirement,
 )
+from rai_toolkit.compliance.nyc_ll144_mapping import (
+    NYC_LL_144_REQUIREMENTS,
+    get_all_nyc_ll144_mit_categories,
+    get_mit_categories_for_nyc_requirement,
+)
 from rai_toolkit.compliance.scorer_registry import (
     SCORER_REGISTRY,
     get_scorer_mapping,
@@ -130,6 +135,9 @@ class ComplianceMappingEngine:
         elif framework == Framework.EU_AI_ACT:
             mit_ids = get_all_required_mit_categories()
             return [MIT_TAXONOMY[id_] for id_ in mit_ids if id_ in MIT_TAXONOMY]
+        elif framework == Framework.NYC_LL_144:
+            mit_ids = get_all_nyc_ll144_mit_categories()
+            return [MIT_TAXONOMY[id_] for id_ in mit_ids if id_ in MIT_TAXONOMY]
         return []
 
     @staticmethod
@@ -143,6 +151,11 @@ class ComplianceMappingEngine:
             return {
                 req.title: req.mit_category_ids
                 for req in EU_AI_ACT_REQUIREMENTS.values()
+            }
+        elif framework == Framework.NYC_LL_144:
+            return {
+                req.title: req.mit_category_ids
+                for req in NYC_LL_144_REQUIREMENTS.values()
             }
         return {}
 
@@ -319,6 +332,31 @@ class ComplianceMappingEngine:
             covered = category_ids & required_mits
             coverage[req_id] = {
                 "article": req.article,
+                "title": req.title,
+                "description": req.description,
+                "total_categories": len(required_mits),
+                "covered_categories": len(covered),
+                "coverage_pct": len(covered) / len(required_mits) * 100 if required_mits else 0,
+                "covered_ids": sorted(covered),
+                "missing_ids": sorted(required_mits - category_ids),
+                "capabilities": req.rai_capabilities,
+            }
+
+        return coverage
+
+    def get_nyc_ll144_coverage(self, profile: ComplianceProfile) -> dict[str, dict[str, Any]]:
+        """Map a profile's categories to NYC LL 144 requirements.
+
+        Returns a dict of NYC LL 144 requirements with their coverage status.
+        """
+        category_ids = set(profile.category_ids)
+        coverage: dict[str, dict[str, Any]] = {}
+
+        for req_id, req in NYC_LL_144_REQUIREMENTS.items():
+            required_mits = set(req.mit_category_ids)
+            covered = category_ids & required_mits
+            coverage[req_id] = {
+                "section": req.section,
                 "title": req.title,
                 "description": req.description,
                 "total_categories": len(required_mits),

--- a/rai_toolkit/compliance/engine.py
+++ b/rai_toolkit/compliance/engine.py
@@ -365,6 +365,7 @@ class ComplianceMappingEngine:
                 "covered_ids": sorted(covered),
                 "missing_ids": sorted(required_mits - category_ids),
                 "capabilities": req.rai_capabilities,
+                "coverage_gaps": req.coverage_gaps,
             }
 
         return coverage

--- a/rai_toolkit/compliance/frameworks.py
+++ b/rai_toolkit/compliance/frameworks.py
@@ -17,6 +17,7 @@ class Framework(Enum):
     MIT_AI_RISK = "mit_ai_risk_repository"
     NIST_AI_RMF = "nist_ai_rmf"
     EU_AI_ACT = "eu_ai_act"
+    NYC_LL_144 = "nyc_local_law_144"
 
 
 class RiskSeverity(Enum):

--- a/rai_toolkit/compliance/nyc_ll144_mapping.py
+++ b/rai_toolkit/compliance/nyc_ll144_mapping.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+"""NYC Local Law 144 compliance mapping for automated employment decision tools.
+
+Maps NYC LL 144 requirements (bias audits, notice, impact ratios) to
+RAI toolkit capabilities and MIT risk categories.
+
+Source: NYC Local Law 144 of 2023 — Automated Employment Decision Tools.
+https://www.nyc.gov/site/ccl/rules/local-law-144.page
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class NYCLL144Requirement:
+    """A NYC LL 144 requirement with mapping to toolkit capabilities.
+
+    Attributes:
+        id: Requirement identifier.
+        section: NYC Administrative Code section reference.
+        title: Short title.
+        description: What the requirement mandates.
+        mit_category_ids: MIT risk categories that help address this requirement.
+        rai_capabilities: How the RAI toolkit helps with compliance.
+    """
+
+    id: str
+    section: str
+    title: str
+    description: str
+    mit_category_ids: list[str] = field(default_factory=list)
+    rai_capabilities: list[str] = field(default_factory=list)
+
+
+NYC_LL_144_REQUIREMENTS: dict[str, NYCLL144Requirement] = {
+    "NYC-LL144-1": NYCLL144Requirement(
+        id="NYC-LL144-1",
+        section="Section 20-144(a)(1)",
+        title="Bias Audit — Annual Bias Assessment",
+        description=(
+            "Employers and employment agencies must conduct an independent bias "
+            "audit of each automated employment decision tool (AEDT) used in the "
+            "city at least once every two years, prior to use or material "
+            "modification. The audit must assess the impact of the tool on "
+            "candidates across protected classes including race, sex, and "
+            "ethnicity."
+        ),
+        mit_category_ids=[
+            "MIT-1.1",  # Unfair discrimination and bias
+            "MIT-1.3",  # Unequal performance across groups
+        ],
+        rai_capabilities=[
+            "FairnessJudge scorer evaluates demographic bias across protected classes",
+            "Bias benchmarks test impact ratios by category",
+            "Evaluation pipeline quantifies disparate impact with normalized scores",
+        ],
+    ),
+    "NYC-LL144-2": NYCLL144Requirement(
+        id="NYC-LL144-2",
+        section="Section 20-144(a)(2)",
+        title="Bias Audit — Impact Ratio Reporting",
+        description=(
+            "The bias audit must calculate and report impact ratios (selection "
+            "rates) for each protected category. An adverse impact threshold "
+            "of 0.8 (the '80% rule') is used to determine whether a protected "
+            "group is disproportionately affected by the AEDT."
+        ),
+        mit_category_ids=[
+            "MIT-1.1",  # Unfair discrimination and bias
+            "MIT-1.3",  # Unequal performance across groups
+        ],
+        rai_capabilities=[
+            "FairnessJudge provides per-group performance metrics and impact ratios",
+            "Comparative evaluations track selection-rate disparities across versions",
+            "Scorer registry supports custom impact-ratio aggregation",
+        ],
+    ),
+    "NYC-LL144-3": NYCLL144Requirement(
+        id="NYC-LL144-3",
+        section="Section 20-144(b)",
+        title="Notice to Candidates",
+        description=(
+            "Employers must provide clear notice to candidates that an AEDT "
+            "will be used in the assessment process. The notice must describe "
+            "the category of measurements or outputs the tool is designed to "
+            "evaluate and any available action to contest or opt out of the "
+            "assessment."
+        ),
+        mit_category_ids=[
+            "MIT-7.2",  # Transparency and explainability
+        ],
+        rai_capabilities=[
+            "Transparency scorer evaluates whether system disclosures are adequate",
+            "Evaluation traces document what inputs the tool processes",
+            "Compliance reports include candidate-facing notices as audit artifacts",
+        ],
+    ),
+    "NYC-LL144-4": NYCLL144Requirement(
+        id="NYC-LL144-4",
+        section="Section 20-144(c)",
+        title="Publication of Bias Audit Results",
+        description=(
+            "Employers must make the bias audit results publicly available, "
+            "including the impact ratios by protected category, on the "
+            "employer's website or through another accessible means. Results "
+            "must be retained for at least two years."
+        ),
+        mit_category_ids=[
+            "MIT-7.2",  # Transparency and explainability
+            "MIT-7.1",  # System failures and robustness
+        ],
+        rai_capabilities=[
+            "Compliance reports generate structured bias-audit documentation",
+            "Versioned evaluation traces preserve audit history for retention",
+            "Evaluation pipeline exports impact-ratio summaries in machine-readable format",
+        ],
+    ),
+    "NYC-LL144-5": NYCLL144Requirement(
+        id="NYC-LL144-5",
+        section="Section 20-144(a)(3)",
+        title="Material Changes — Re-Audit Requirement",
+        description=(
+            "A new bias audit must be conducted whenever a material change is "
+            "made to an AEDT that is reasonably likely to produce a different "
+            "impact ratio. This includes changes to the tool's algorithms, "
+            "training data, or the categories of data it evaluates."
+        ),
+        mit_category_ids=[
+            "MIT-1.1",  # Unfair discrimination and bias
+            "MIT-7.1",  # System failures and robustness
+        ],
+        rai_capabilities=[
+            "Comparative evaluations detect performance drift after model updates",
+            "Evaluation versioning tracks score changes across tool revisions",
+            "Bias benchmarks re-run automatically on material-change detection",
+        ],
+    ),
+    "NYC-LL144-6": NYCLL144Requirement(
+        id="NYC-LL144-6",
+        section="Section 20-144(d)",
+        title="Vendor Certification and Liability",
+        description=(
+            "AEDT vendors must certify to the employer that the tool has "
+            "undergone the required bias audit and provide the results. "
+            "Both the employer and the vendor may be held liable for "
+            "violations of the law."
+        ),
+        mit_category_ids=[
+            "MIT-7.2",  # Transparency and explainability
+            "MIT-2.2",  # Security and resilience
+        ],
+        rai_capabilities=[
+            "Evaluation reports can be shared with vendors as certification evidence",
+            "Trace and feedback workflows capture vendor-provided audit data",
+            "Compliance engine surfaces vendor-certification status in reports",
+        ],
+    ),
+}
+
+
+def get_requirement(requirement_id: str) -> NYCLL144Requirement | None:
+    """Look up a NYC LL 144 requirement."""
+    return NYC_LL_144_REQUIREMENTS.get(requirement_id)
+
+
+def get_all_nyc_ll144_mit_categories() -> list[str]:
+    """Get all MIT risk categories relevant to NYC LL 144 compliance."""
+    categories: set[str] = set()
+    for req in NYC_LL_144_REQUIREMENTS.values():
+        categories.update(req.mit_category_ids)
+    return sorted(categories)
+
+
+def get_mit_categories_for_nyc_requirement(requirement_id: str) -> list[str]:
+    """Get MIT risk categories that address a specific NYC LL 144 requirement."""
+    req = NYC_LL_144_REQUIREMENTS.get(requirement_id)
+    return req.mit_category_ids if req else []
+
+
+# Reviewer-facing subtitles for framework coverage tables (Weave panel, HTML
+# report, Streamlit). Kept short so rows stay scannable in narrow panels.
+NYC_SECTION_DISPLAY_SUBTITLES: dict[str, str] = {
+    "NYC-LL144-1": "Annual bias audit",
+    "NYC-LL144-2": "Impact ratio reporting",
+    "NYC-LL144-3": "Candidate notice",
+    "NYC-LL144-4": "Publish audit results",
+    "NYC-LL144-5": "Re-audit on material change",
+    "NYC-LL144-6": "Vendor certification",
+}
+
+
+def format_nyc_ll144_framework_label(
+    requirement_id: str,
+    *,
+    section: str | None = None,
+    title: str | None = None,
+) -> str:
+    """Build a framework row label like ``NYC LL 144: Sec 20-144(a)(1) (Annual bias audit)``."""
+    section_label = section or requirement_id
+    subtitle = NYC_SECTION_DISPLAY_SUBTITLES.get(requirement_id)
+    if subtitle is None and title:
+        subtitle = title
+    if subtitle:
+        return f"NYC LL 144: {section_label} ({subtitle})"
+    return f"NYC LL 144: {section_label}"

--- a/rai_toolkit/compliance/nyc_ll144_mapping.py
+++ b/rai_toolkit/compliance/nyc_ll144_mapping.py
@@ -2,13 +2,46 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-PackageName: rai-toolkit
 
-"""NYC Local Law 144 compliance mapping for automated employment decision tools.
+"""NYC Local Law 144 of 2021 compliance mapping for automated employment
+decision tools (AEDTs).
 
-Maps NYC LL 144 requirements (bias audits, notice, impact ratios) to
+Maps the obligations in NYC Admin. Code Sec. Sec. 20-870 through 20-874 and
+the DCWP implementing rule (6 RCNY Subchapter T, Sec. Sec. 5-300 to 5-304) to
 RAI toolkit capabilities and MIT risk categories.
 
-Source: NYC Local Law 144 of 2023 — Automated Employment Decision Tools.
-https://www.nyc.gov/site/ccl/rules/local-law-144.page
+Key facts encoded here (verified against the primary sources below):
+
+- It is unlawful for an employer or employment agency to use an AEDT in NYC
+  unless a bias audit was conducted no more than one year prior to use
+  (Sec. 20-871(a)(1); rule 5-301(a)). Audit currency is time-based only;
+  the law has no material-change re-audit trigger.
+- The audit (an impartial evaluation by an independent auditor) computes
+  selection rates (or scoring rates against the sample median) and impact
+  ratios for each EEO-1 Component 1 category: sex, race/ethnicity, and
+  intersectional categories (rule 5-301(b)-(c)). Neither the law nor the
+  rule sets a numeric impact-ratio compliance threshold (such as 0.8) and
+  DCWP states the law requires no specific action based only on audit
+  results.
+- A summary of the most recent audit results and the date the tool was
+  first distributed must be publicly posted on the employer's employment
+  section of its website, remaining posted for at least six months after
+  the latest use of the AEDT (Sec. 20-871(a)(2); rule 5-303).
+- Candidates and employees who reside in NYC must receive notice at least
+  10 business days before the AEDT is used, covering: that an AEDT will
+  be used, instructions for requesting an alternative selection process
+  or a reasonable accommodation under other laws (if available), and the
+  job qualifications and characteristics the tool will assess
+  (Sec. 20-871(b); rule 5-304).
+- Obligations fall on the employer or employment agency; the vendor that
+  created the tool is not responsible for the bias audit (DCWP FAQ). A
+  vendor may commission an audit of its own tool, but the employer
+  remains ultimately responsible.
+
+Sources:
+- Law text (Admin. Code ch. 5, subch. 25): https://codelibrary.amlegal.com/codes/newyorkcity/latest/NYCadmin
+- DCWP rule (6 RCNY Subchapter T): https://rules.cityofnewyork.us/wp-content/uploads/2023/04/DCWP-NOA-for-Use-of-Automated-Employment-Decisionmaking-Tools-2.pdf
+- DCWP AEDT page: https://www.nyc.gov/site/dca/about/automated-employment-decision-tools.page
+- DCWP FAQ: https://www.nyc.gov/assets/dca/downloads/pdf/about/DCWP-AEDT-FAQ.pdf
 """
 
 from __future__ import annotations
@@ -18,15 +51,16 @@ from dataclasses import dataclass, field
 
 @dataclass
 class NYCLL144Requirement:
-    """A NYC LL 144 requirement with mapping to toolkit capabilities.
+    """A NYC LL 144 obligation with mapping to toolkit capabilities.
 
     Attributes:
         id: Requirement identifier.
-        section: NYC Administrative Code section reference.
+        section: NYC Administrative Code / rule section reference.
         title: Short title.
-        description: What the requirement mandates.
-        mit_category_ids: MIT risk categories that help address this requirement.
-        rai_capabilities: How the RAI toolkit helps with compliance.
+        description: What the law mandates.
+        mit_category_ids: MIT risk categories relevant to this obligation.
+        rai_capabilities: Implemented toolkit capabilities that assist here.
+        coverage_gaps: LL 144 obligations the toolkit does not implement.
     """
 
     id: str
@@ -35,129 +69,141 @@ class NYCLL144Requirement:
     description: str
     mit_category_ids: list[str] = field(default_factory=list)
     rai_capabilities: list[str] = field(default_factory=list)
+    coverage_gaps: list[str] = field(default_factory=list)
 
 
 NYC_LL_144_REQUIREMENTS: dict[str, NYCLL144Requirement] = {
     "NYC-LL144-1": NYCLL144Requirement(
         id="NYC-LL144-1",
-        section="Section 20-144(a)(1)",
-        title="Bias Audit — Annual Bias Assessment",
+        section="Section 20-871(a)(1); rule 5-301(a)",
+        title="Annual Bias Audit",
         description=(
-            "Employers and employment agencies must conduct an independent bias "
-            "audit of each automated employment decision tool (AEDT) used in the "
-            "city at least once every two years, prior to use or material "
-            "modification. The audit must assess the impact of the tool on "
-            "candidates across protected classes including race, sex, and "
-            "ethnicity."
+            "It is unlawful for an employer or employment agency to use an "
+            "automated employment decision tool (AEDT) in New York City "
+            "unless a bias audit was conducted no more than one year prior "
+            "to such use. The bias audit is an impartial evaluation by an "
+            "independent auditor that includes testing the AEDT for disparate "
+            "impact on EEO-1 Component 1 categories (sex, race, and "
+            "ethnicity)."
         ),
         mit_category_ids=[
             "MIT-1.1",  # Unfair discrimination and bias
             "MIT-1.3",  # Unequal performance across groups
         ],
         rai_capabilities=[
-            "FairnessJudge scorer evaluates demographic bias across protected classes",
-            "Bias benchmarks test impact ratios by category",
-            "Evaluation pipeline quantifies disparate impact with normalized scores",
+            "FairnessJudge scorer flags demographic bias and stereotyping "
+            "in AEDT outputs (MIT-1.1)",
+            "BBQ and BOLD example datasets provide demographic-split bias "
+            "benchmarks for evaluation runs",
+            "Evaluation pipeline aggregates per-scorer results for bias "
+            "evidence gathering",
+        ],
+        coverage_gaps=[
+            "Audits must be performed by an independent auditor; the "
+            "toolkit's LLM-judge scores are not an independent bias audit",
+            "The toolkit does not track audit dates or enforce the one-year "
+            "currency window",
         ],
     ),
     "NYC-LL144-2": NYCLL144Requirement(
         id="NYC-LL144-2",
-        section="Section 20-144(a)(2)",
-        title="Bias Audit — Impact Ratio Reporting",
+        section="Section 20-870 (definition of bias audit); rule 5-301(b)-(c)",
+        title="Impact Ratio Calculation and Reporting",
         description=(
-            "The bias audit must calculate and report impact ratios (selection "
-            "rates) for each protected category. An adverse impact threshold "
-            "of 0.8 (the '80% rule') is used to determine whether a protected "
-            "group is disproportionately affected by the AEDT."
+            "The bias audit must compute and report, for each EEO-1 "
+            "Component 1 category (sex, race/ethnicity, and intersectional "
+            "combinations), the selection rate (or, for scoring tools, the "
+            "scoring rate against the sample median) and the impact ratio "
+            "(the category's rate divided by the rate of the most-selected "
+            "or highest-scoring category). Categories representing less than "
+            "2% of the data may be excluded from impact-ratio calculations "
+            "with justification, but applicant counts and rates must still "
+            "be shown. Neither the law nor the rule establishes a numeric "
+            "impact-ratio threshold for compliance."
         ),
         mit_category_ids=[
             "MIT-1.1",  # Unfair discrimination and bias
             "MIT-1.3",  # Unequal performance across groups
         ],
         rai_capabilities=[
-            "FairnessJudge provides per-group performance metrics and impact ratios",
-            "Comparative evaluations track selection-rate disparities across versions",
-            "Scorer registry supports custom impact-ratio aggregation",
+            "BBQ example dataset is split across demographic categories for "
+            "per-group performance comparison (MIT-1.3)",
+            "Evaluation pipeline reports per-category scores that can feed "
+            "an external impact-ratio analysis",
+        ],
+        coverage_gaps=[
+            "The toolkit does not calculate selection rates, scoring rates, "
+            "or impact ratios; these are computed by the independent auditor",
+            "The toolkit does not model EEO-1 Component 1 category "
+            "taxonomies or the intersectional-category requirements",
+            "No four-fifths-rule or other numeric threshold is implemented; "
+            "the law sets none",
         ],
     ),
     "NYC-LL144-3": NYCLL144Requirement(
         id="NYC-LL144-3",
-        section="Section 20-144(b)",
-        title="Notice to Candidates",
+        section="Section 20-871(b); rule 5-304",
+        title="Candidate Notice",
         description=(
-            "Employers must provide clear notice to candidates that an AEDT "
-            "will be used in the assessment process. The notice must describe "
-            "the category of measurements or outputs the tool is designed to "
-            "evaluate and any available action to contest or opt out of the "
-            "assessment."
+            "Employers and employment agencies must give each NYC-resident "
+            "candidate or employee written notice at least 10 business days "
+            "before an AEDT is used. The notice must state that an AEDT will "
+            "be used in the assessment, include instructions for requesting "
+            "an alternative selection process or a reasonable accommodation "
+            "under other laws (if available), and describe the job "
+            "qualifications and characteristics the AEDT will assess. If "
+            "this data disclosure is not on the employer's website, the "
+            "employer must respond within 30 days to written requests about "
+            "the type of data the tool collects, its source, and the data "
+            "retention policy."
         ),
         mit_category_ids=[
+            "MIT-5.1",  # Overreliance and false transparency
             "MIT-7.2",  # Transparency and explainability
         ],
         rai_capabilities=[
-            "Transparency scorer evaluates whether system disclosures are adequate",
-            "Evaluation traces document what inputs the tool processes",
-            "Compliance reports include candidate-facing notices as audit artifacts",
+            "TransparencyJudge scorer checks that the system discloses its "
+            "nature and limitations to users (MIT-5.1)",
+            "Evaluation traces record the inputs and outputs the AEDT "
+            "processes, supporting the 30-day data-request response",
+        ],
+        coverage_gaps=[
+            "Notice delivery, 10-business-day timing, and accommodation "
+            "request workflows are employer-side process requirements the "
+            "toolkit does not implement",
+            "The toolkit does not manage the website data-disclosure "
+            "posting required by rule 5-304(d)",
         ],
     ),
     "NYC-LL144-4": NYCLL144Requirement(
         id="NYC-LL144-4",
-        section="Section 20-144(c)",
-        title="Publication of Bias Audit Results",
+        section="Section 20-871(a)(2); rule 5-303",
+        title="Publication of Audit Results",
         description=(
-            "Employers must make the bias audit results publicly available, "
-            "including the impact ratios by protected category, on the "
-            "employer's website or through another accessible means. Results "
-            "must be retained for at least two years."
+            "Before using an AEDT, the employer or employment agency must "
+            "publicly post on the employment section of its website the date "
+            "of the most recent bias audit and a summary of the results "
+            "(including the data source, the number of applicants or "
+            "candidates, selection or scoring rates, and impact ratios for "
+            "all categories), together with the date the AEDT was first "
+            "distributed. The summary must remain posted for at least six "
+            "months after the latest use of the AEDT."
         ),
         mit_category_ids=[
+            "MIT-5.1",  # Overreliance and false transparency
             "MIT-7.2",  # Transparency and explainability
-            "MIT-7.1",  # System failures and robustness
         ],
         rai_capabilities=[
-            "Compliance reports generate structured bias-audit documentation",
-            "Versioned evaluation traces preserve audit history for retention",
-            "Evaluation pipeline exports impact-ratio summaries in machine-readable format",
+            "Assessment reports document the scorers, thresholds, and "
+            "per-category results that can accompany a published audit "
+            "summary",
+            "Weave-traced evaluation runs preserve a versioned history of "
+            "bias-evaluation results",
         ],
-    ),
-    "NYC-LL144-5": NYCLL144Requirement(
-        id="NYC-LL144-5",
-        section="Section 20-144(a)(3)",
-        title="Material Changes — Re-Audit Requirement",
-        description=(
-            "A new bias audit must be conducted whenever a material change is "
-            "made to an AEDT that is reasonably likely to produce a different "
-            "impact ratio. This includes changes to the tool's algorithms, "
-            "training data, or the categories of data it evaluates."
-        ),
-        mit_category_ids=[
-            "MIT-1.1",  # Unfair discrimination and bias
-            "MIT-7.1",  # System failures and robustness
-        ],
-        rai_capabilities=[
-            "Comparative evaluations detect performance drift after model updates",
-            "Evaluation versioning tracks score changes across tool revisions",
-            "Bias benchmarks re-run automatically on material-change detection",
-        ],
-    ),
-    "NYC-LL144-6": NYCLL144Requirement(
-        id="NYC-LL144-6",
-        section="Section 20-144(d)",
-        title="Vendor Certification and Liability",
-        description=(
-            "AEDT vendors must certify to the employer that the tool has "
-            "undergone the required bias audit and provide the results. "
-            "Both the employer and the vendor may be held liable for "
-            "violations of the law."
-        ),
-        mit_category_ids=[
-            "MIT-7.2",  # Transparency and explainability
-            "MIT-2.2",  # Security and resilience
-        ],
-        rai_capabilities=[
-            "Evaluation reports can be shared with vendors as certification evidence",
-            "Trace and feedback workflows capture vendor-provided audit data",
-            "Compliance engine surfaces vendor-certification status in reports",
+        coverage_gaps=[
+            "The toolkit does not produce the statutory audit summary "
+            "(dates, applicant counts, rates, impact ratios) or manage the "
+            "six-month posting obligation",
         ],
     ),
 }
@@ -189,8 +235,6 @@ NYC_SECTION_DISPLAY_SUBTITLES: dict[str, str] = {
     "NYC-LL144-2": "Impact ratio reporting",
     "NYC-LL144-3": "Candidate notice",
     "NYC-LL144-4": "Publish audit results",
-    "NYC-LL144-5": "Re-audit on material change",
-    "NYC-LL144-6": "Vendor certification",
 }
 
 
@@ -200,7 +244,7 @@ def format_nyc_ll144_framework_label(
     section: str | None = None,
     title: str | None = None,
 ) -> str:
-    """Build a framework row label like ``NYC LL 144: Sec 20-144(a)(1) (Annual bias audit)``."""
+    """Build a framework row label like ``NYC LL 144: Sec 20-871(a)(1) (Annual bias audit)``."""
     section_label = section or requirement_id
     subtitle = NYC_SECTION_DISPLAY_SUBTITLES.get(requirement_id)
     if subtitle is None and title:

--- a/rai_toolkit/toolkit.py
+++ b/rai_toolkit/toolkit.py
@@ -118,6 +118,10 @@ class RAIToolkit:
         """Get EU AI Act coverage for a profile."""
         return self.engine.get_eu_ai_act_coverage(profile)
 
+    def get_nyc_ll144_coverage(self, profile: ComplianceProfile) -> dict[str, Any]:
+        """Get NYC Local Law 144 coverage for a profile."""
+        return self.engine.get_nyc_ll144_coverage(profile)
+
     # --- Datasets ---
 
     @staticmethod

--- a/tests/test_nyc_ll144_framework.py
+++ b/tests/test_nyc_ll144_framework.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for NYC LL 144 compliance framework integration."""
+
+from __future__ import annotations
+
+from rai_toolkit.compliance.engine import ComplianceMappingEngine
+from rai_toolkit.compliance.frameworks import Framework
+
+
+def test_nyc_ll_144_framework_is_registered() -> None:
+    """NYC LL 144 appears in the framework registry."""
+    eng = ComplianceMappingEngine()
+    frameworks = eng.get_frameworks()
+    assert Framework.NYC_LL_144 in frameworks
+
+
+def test_nyc_ll_144_resolves_mit_categories() -> None:
+    """Resolving NYC LL 144 categories returns the expected MIT categories."""
+    eng = ComplianceMappingEngine()
+    categories = eng.get_categories(Framework.NYC_LL_144)
+    ids = {c.id for c in categories}
+    # The six requirements cover: MIT-1.1, MIT-1.3, MIT-7.2, MIT-7.1, MIT-2.2
+    assert ids == {"MIT-1.1", "MIT-1.3", "MIT-2.2", "MIT-7.1", "MIT-7.2"}
+
+
+def test_nyc_ll_144_domains_are_structured() -> None:
+    """Each NYC LL 144 requirement maps to its MIT category IDs."""
+    eng = ComplianceMappingEngine()
+    domains = eng.get_domains(Framework.NYC_LL_144)
+    assert len(domains) == 6
+    for title, mit_ids in domains.items():
+        assert isinstance(mit_ids, list)
+        assert len(mit_ids) > 0
+
+
+def test_nyc_ll_144_coverage_partial() -> None:
+    """Coverage reflects partial category inclusion correctly."""
+    eng = ComplianceMappingEngine()
+    profile = eng.create_profile(
+        framework=Framework.NYC_LL_144,
+        category_ids=["MIT-1.1"],
+        name="Partial Coverage Test",
+    )
+    coverage = eng.get_nyc_ll144_coverage(profile)
+    # MIT-1.1 covers LL144-1 and LL144-2 fully; others are partially covered
+    assert coverage["NYC-LL144-1"]["coverage_pct"] == 50.0
+    assert coverage["NYC-LL144-2"]["coverage_pct"] == 50.0
+    assert coverage["NYC-LL144-3"]["coverage_pct"] == 0.0
+    assert len(coverage["NYC-LL144-3"]["missing_ids"]) == 1
+
+
+def test_nyc_ll_144_coverage_full() -> None:
+    """Full category set yields 100% on every requirement."""
+    eng = ComplianceMappingEngine()
+    profile = eng.create_profile(
+        framework=Framework.NYC_LL_144,
+        category_ids=["MIT-1.1", "MIT-1.3", "MIT-2.2", "MIT-7.1", "MIT-7.2"],
+        name="Full Coverage Test",
+    )
+    coverage = eng.get_nyc_ll144_coverage(profile)
+    for req_id, cov in coverage.items():
+        assert cov["coverage_pct"] == 100.0, f"{req_id} not fully covered"
+        assert cov["missing_ids"] == []

--- a/tests/test_nyc_ll144_framework.py
+++ b/tests/test_nyc_ll144_framework.py
@@ -48,7 +48,9 @@ def test_nyc_ll_144_bias_audit_window_is_one_year() -> None:
     audit_req = NYC_LL_144_REQUIREMENTS["NYC-LL144-1"]
     assert "one year" in audit_req.description
     assert "two years" not in audit_req.description
-    assert "material" not in audit_req.description.lower() or "no material" in audit_req.description.lower()
+    # Audit currency is time-based only; there is no material-change trigger.
+    assert "material change" not in audit_req.description.lower()
+    assert "material modification" not in audit_req.description.lower()
 
 
 def test_nyc_ll_144_no_numeric_impact_ratio_threshold() -> None:
@@ -56,9 +58,13 @@ def test_nyc_ll_144_no_numeric_impact_ratio_threshold() -> None:
     audit_req = NYC_LL_144_REQUIREMENTS["NYC-LL144-2"]
     assert "0.8" not in audit_req.description
     assert "80%" not in audit_req.description
-    assert "threshold" in audit_req.description
-    assert "no numeric" in audit_req.description or "no numeric" in " ".join(
-        gap for gap in audit_req.coverage_gaps
+    # The description states the absence of a threshold in plain terms.
+    assert "no numeric impact-ratio threshold" in audit_req.description.lower() or (
+        "neither the law nor the rule establishes" in audit_req.description.lower()
+    )
+    joined_gaps = " ".join(audit_req.coverage_gaps).lower()
+    assert "threshold" in joined_gaps and (
+        "sets none" in joined_gaps or "no numeric" in joined_gaps or "none" in joined_gaps
     )
 
 

--- a/tests/test_nyc_ll144_framework.py
+++ b/tests/test_nyc_ll144_framework.py
@@ -1,12 +1,26 @@
 # SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
 
-"""Tests for NYC LL 144 compliance framework integration."""
+"""Tests for NYC LL 144 compliance framework integration.
+
+Pins the authoritative legal facts for NYC Local Law 144 of 2021
+(Admin. Code Sec. Sec. 20-870 to 20-874; DCWP rule 6 RCNY Subchapter T):
+one-year bias-audit window, 10-business-day notice, six-month posting
+retention, no numeric impact-ratio threshold, and employer-side
+responsibility.
+"""
 
 from __future__ import annotations
 
 from rai_toolkit.compliance.engine import ComplianceMappingEngine
 from rai_toolkit.compliance.frameworks import Framework
+from rai_toolkit.compliance.nyc_ll144_mapping import (
+    NYC_LL_144_REQUIREMENTS,
+    format_nyc_ll144_framework_label,
+    get_all_nyc_ll144_mit_categories,
+    get_mit_categories_for_nyc_requirement,
+)
 
 
 def test_nyc_ll_144_framework_is_registered() -> None:
@@ -16,23 +30,91 @@ def test_nyc_ll_144_framework_is_registered() -> None:
     assert Framework.NYC_LL_144 in frameworks
 
 
+def test_nyc_ll_144_sections_cite_authoritative_law() -> None:
+    """Requirements cite Sec. 20-870/20-871 and the DCWP rule, not Sec. 20-144."""
+    for req in NYC_LL_144_REQUIREMENTS.values():
+        assert "20-144" not in req.section, (
+            f"{req.id} cites nonexistent section 20-144; the governing law "
+            "is Admin. Code sections 20-870 through 20-874"
+        )
+        assert "20-87" in req.section or "5-30" in req.section, (
+            f"{req.id} must cite the law (20-870/20-871) or the DCWP rule "
+            f"(5-300 to 5-304); got {req.section}"
+        )
+
+
+def test_nyc_ll_144_bias_audit_window_is_one_year() -> None:
+    """The bias-audit currency window is one year, not two."""
+    audit_req = NYC_LL_144_REQUIREMENTS["NYC-LL144-1"]
+    assert "one year" in audit_req.description
+    assert "two years" not in audit_req.description
+    assert "material" not in audit_req.description.lower() or "no material" in audit_req.description.lower()
+
+
+def test_nyc_ll_144_no_numeric_impact_ratio_threshold() -> None:
+    """The law sets no numeric impact-ratio compliance threshold."""
+    audit_req = NYC_LL_144_REQUIREMENTS["NYC-LL144-2"]
+    assert "0.8" not in audit_req.description
+    assert "80%" not in audit_req.description
+    assert "threshold" in audit_req.description
+    assert "no numeric" in audit_req.description or "no numeric" in " ".join(
+        gap for gap in audit_req.coverage_gaps
+    )
+
+
+def test_nyc_ll_144_notice_is_10_business_days() -> None:
+    """Notice must be provided at least 10 business days before use."""
+    notice_req = NYC_LL_144_REQUIREMENTS["NYC-LL144-3"]
+    assert "10 business days" in notice_req.description
+
+
+def test_nyc_ll_144_posting_retention_is_six_months() -> None:
+    """Audit summaries must remain posted for at least six months after latest use."""
+    posting_req = NYC_LL_144_REQUIREMENTS["NYC-LL144-4"]
+    assert "six months" in posting_req.description
+    assert "two years" not in posting_req.description
+
+
+def test_nyc_ll_144_no_material_change_or_vendor_requirements() -> None:
+    """The law has no material-change re-audit trigger or vendor certification."""
+    for req_id, req in NYC_LL_144_REQUIREMENTS.items():
+        assert "material change" not in req.title.lower()
+        assert "vendor" not in req.title.lower()
+    titles = {req.title.lower() for req in NYC_LL_144_REQUIREMENTS.values()}
+    assert not any("re-audit" in t for t in titles)
+    assert not any("certification" in t for t in titles)
+
+
 def test_nyc_ll_144_resolves_mit_categories() -> None:
     """Resolving NYC LL 144 categories returns the expected MIT categories."""
     eng = ComplianceMappingEngine()
     categories = eng.get_categories(Framework.NYC_LL_144)
     ids = {c.id for c in categories}
-    # The six requirements cover: MIT-1.1, MIT-1.3, MIT-7.2, MIT-7.1, MIT-2.2
-    assert ids == {"MIT-1.1", "MIT-1.3", "MIT-2.2", "MIT-7.1", "MIT-7.2"}
+    # The four requirements cover: MIT-1.1, MIT-1.3 (bias), MIT-5.1, MIT-7.2
+    # (transparency). MIT-2.2/7.1 were dropped with the removed vendor and
+    # material-change requirements.
+    assert ids == {"MIT-1.1", "MIT-1.3", "MIT-5.1", "MIT-7.2"}
+    assert get_all_nyc_ll144_mit_categories() == ["MIT-1.1", "MIT-1.3", "MIT-5.1", "MIT-7.2"]
 
 
 def test_nyc_ll_144_domains_are_structured() -> None:
     """Each NYC LL 144 requirement maps to its MIT category IDs."""
     eng = ComplianceMappingEngine()
     domains = eng.get_domains(Framework.NYC_LL_144)
-    assert len(domains) == 6
+    assert len(domains) == 4
     for title, mit_ids in domains.items():
         assert isinstance(mit_ids, list)
         assert len(mit_ids) > 0
+
+
+def test_nyc_ll_144_capabilities_and_gaps_are_documented() -> None:
+    """Every requirement lists implemented capabilities and honest gaps."""
+    for req in NYC_LL_144_REQUIREMENTS.values():
+        assert req.rai_capabilities, f"{req.id} has no capabilities"
+        assert req.coverage_gaps, f"{req.id} must document coverage gaps"
+        # Capability claims must not overstate: no impact-ratio calculation claims
+        joined = " ".join(req.rai_capabilities)
+        assert "impact ratios" not in joined or "does not" in joined
 
 
 def test_nyc_ll_144_coverage_partial() -> None:
@@ -44,11 +126,13 @@ def test_nyc_ll_144_coverage_partial() -> None:
         name="Partial Coverage Test",
     )
     coverage = eng.get_nyc_ll144_coverage(profile)
-    # MIT-1.1 covers LL144-1 and LL144-2 fully; others are partially covered
+    # MIT-1.1 covers half of LL144-1/2 (each needs MIT-1.1 + MIT-1.3)
     assert coverage["NYC-LL144-1"]["coverage_pct"] == 50.0
     assert coverage["NYC-LL144-2"]["coverage_pct"] == 50.0
+    # Notice and posting requirements need MIT-5.1 + MIT-7.2
     assert coverage["NYC-LL144-3"]["coverage_pct"] == 0.0
-    assert len(coverage["NYC-LL144-3"]["missing_ids"]) == 1
+    assert coverage["NYC-LL144-4"]["coverage_pct"] == 0.0
+    assert len(coverage["NYC-LL144-3"]["missing_ids"]) == 2
 
 
 def test_nyc_ll_144_coverage_full() -> None:
@@ -56,10 +140,32 @@ def test_nyc_ll_144_coverage_full() -> None:
     eng = ComplianceMappingEngine()
     profile = eng.create_profile(
         framework=Framework.NYC_LL_144,
-        category_ids=["MIT-1.1", "MIT-1.3", "MIT-2.2", "MIT-7.1", "MIT-7.2"],
+        category_ids=["MIT-1.1", "MIT-1.3", "MIT-5.1", "MIT-7.2"],
         name="Full Coverage Test",
     )
     coverage = eng.get_nyc_ll144_coverage(profile)
     for req_id, cov in coverage.items():
         assert cov["coverage_pct"] == 100.0, f"{req_id} not fully covered"
         assert cov["missing_ids"] == []
+        assert cov["coverage_gaps"], f"{req_id} should still surface gaps even at full MIT coverage"
+
+
+def test_nyc_ll_144_framework_label_format() -> None:
+    """Framework row labels render like ``NYC LL 144: ... (Annual bias audit)``."""
+    label = format_nyc_ll144_framework_label(
+        "NYC-LL144-1",
+        section="Section 20-871(a)(1); rule 5-301(a)",
+    )
+    assert label == "NYC LL 144: Section 20-871(a)(1); rule 5-301(a) (Annual bias audit)"
+    fallback = format_nyc_ll144_framework_label("NYC-LL144-1")
+    assert fallback == "NYC LL 144: NYC-LL144-1 (Annual bias audit)"
+
+
+def test_nyc_ll_144_requirement_helpers() -> None:
+    """Helper lookups resolve requirement MIT mappings."""
+    assert get_mit_categories_for_nyc_requirement("NYC-LL144-1") == ["MIT-1.1", "MIT-1.3"]
+    assert get_mit_categories_for_nyc_requirement("NYC-LL144-9") == []
+    from rai_toolkit.compliance.nyc_ll144_mapping import get_requirement
+
+    assert get_requirement("NYC-LL144-2") is not None
+    assert get_requirement("NYC-LL144-9") is None


### PR DESCRIPTION
## Summary

Add a compliance framework mapping for **NYC Local Law 144 of 2021**, which governs automated employment decision tools (AEDTs) used in hiring/promotion within New York City.

Rebuilt from the authoritative sources per review: NYC Admin. Code §§20-870 through 20-874 and the DCWP implementing rule (6 RCNY Subchapter T, §§5-300 to 5-304), plus the DCWP FAQ.

## Requirements covered

| ID | Section | Title |
|---|---|---|
| NYC-LL144-1 | §20-871(a)(1); rule 5-301(a) | Annual Bias Audit |
| NYC-LL144-2 | §20-870; rule 5-301(b)-(c) | Impact Ratio Calculation and Reporting |
| NYC-LL144-3 | §20-871(b); rule 5-304 | Candidate Notice |
| NYC-LL144-4 | §20-871(a)(2); rule 5-303 | Publication of Audit Results |

Legal facts pinned in the mapping and tests:

- Bias audit conducted **no more than one year prior to use** (time-based currency only — the law has no material-change re-audit trigger)
- Impact ratios = category selection/scoring rate ÷ most-selected/highest-scoring category rate, across EEO-1 Component 1 sex, race/ethnicity, and intersectional categories; **the law sets no numeric compliance threshold (no 0.8/80% rule)** and requires no specific action based only on audit results
- **10 business days** advance written notice to NYC residents, covering AEDT use, alternative-selection-process/accommodation request instructions, and job qualifications/characteristics assessed (no general contest/opt-out right)
- Audit summary + distribution date posted on the employment section of the website, retained **at least six months after latest use**
- Obligations fall on the employer/employment agency; the vendor is not responsible for the bias audit (DCWP FAQ)

## Changes

- `rai_toolkit/compliance/frameworks.py` — add `NYC_LL_144` to the `Framework` enum
- `rai_toolkit/compliance/nyc_ll144_mapping.py` — new mapping module: `NYCLL144Requirement` dataclass (now with `coverage_gaps`), requirements dict, and helper functions (`get_requirement`, `get_all_nyc_ll144_mit_categories`, `get_mit_categories_for_nyc_requirement`), plus display subtitles and `format_nyc_ll144_framework_label`
- `rai_toolkit/compliance/engine.py` — wire NYC LL 144 into `get_categories`/`get_domains`; add `get_nyc_ll144_coverage` (coverage dict includes `coverage_gaps`)
- `rai_toolkit/toolkit.py` — expose `get_nyc_ll144_coverage`
- `rai_toolkit/assessment/assessor.py` — render NYC LL 144 requirement rows in assessments (mirrors the EU AI Act block)
- `tests/test_nyc_ll144_framework.py` — tests covering registration, category resolution, domain structure, partial/full coverage, and fact-pinning: one-year audit window, 10-business-day notice, six-month posting, absence of §20-144 citations, no numeric threshold, no material-change/vendor requirements

Capability claims now describe only implemented behavior (FairnessJudge output-bias judging, BBQ/BOLD demographic-split benchmarks, evaluation traces), with each requirement's unimplemented obligations recorded as `coverage_gaps` (independent-audit requirement, impact-ratio math, notice/posting workflow management).

Branch is rebased on current `main` (the unrelated #33 scorer-name commit is removed). Closes #8.

## Testing

- All 89 tests pass (75 existing + 14 NYC).
- CI gates: `ruff check --select E9,F63,F7,F82` clean, `reuse lint` compliant (115/115), `git diff --check` clean.

## Sources

- Law text: https://codelibrary.amlegal.com/codes/newyorkcity/latest/NYCadmin
- DCWP rule: https://rules.cityofnewyork.us/wp-content/uploads/2023/04/DCWP-NOA-for-Use-of-Automated-Employment-Decisionmaking-Tools-2.pdf
- DCWP AEDT page: https://www.nyc.gov/site/dca/about/automated-employment-decision-tools.page
- DCWP FAQ: https://www.nyc.gov/assets/dca/downloads/pdf/about/DCWP-AEDT-FAQ.pdf