### PR TITLE
fix: preserve configured names for Weave RAI scorers

### DIFF
--- a/integrations/weave_integration/scorers.py
+++ b/integrations/weave_integration/scorers.py
@@ -92,12 +92,12 @@ class WeaveRAIScorer(weave.Scorer):
     _rai_scorer: BaseScorer | None = None
 
     def __init__(self, rai_scorer: BaseScorer, **kwargs: Any) -> None:
-        # Set ``name`` (a weave.Scorer base field) to the rai scorer's class
-        # name so the Evals UI shows e.g. ``FairnessJudge`` in the scorer
-        # column instead of an unhelpful object-ref label. ``name`` also
-        # drives ``Scorer.display_name``.
+        # Set ``name`` (a weave.Scorer base field) from the configured RAI
+        # scorer name. Weave keys evaluation results by this value, so using
+        # only the class name would collapse separately configured instances
+        # of the same scorer. ``name`` also drives ``Scorer.display_name``.
         rai_class = type(rai_scorer).__name__
-        kwargs.setdefault("name", rai_class)
+        kwargs.setdefault("name", rai_scorer.name or rai_class)
         super().__init__(
             rai_scorer_name=rai_scorer.name,
             rai_scorer_category=rai_scorer.category,

--- a/tests/test_weave_scorer_names.py
+++ b/tests/test_weave_scorer_names.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 Yusef Syed
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+"""Regression coverage for configured RAI scorer names in Weave evaluations."""
+
+import pytest
+
+try:
+    import weave
+except ModuleNotFoundError:
+    weave = None
+
+from rai_toolkit.scorers.base import BaseScorer, ScorerResult
+
+
+class _ConfiguredScoreScorer(BaseScorer):
+    def score(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: object,
+    ) -> ScorerResult:
+        score = 1.0 if self.name == "alpha" else 0.0
+        return ScorerResult(
+            score=score,
+            passed=bool(score),
+            category="",
+            explanation=self.name,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(weave is None, reason="requires the weave extra")
+async def test_weave_evaluation_keeps_configured_names_for_same_scorer_class() -> None:
+    from integrations.weave_integration.scorers import make_weave_rai_scorer
+
+    class StaticWeaveModel(weave.Model):  # type: ignore[union-attr,misc]
+        @weave.op()  # type: ignore[union-attr]
+        async def predict(self, input_text: str) -> dict[str, str]:
+            return {"output": "response"}
+
+    evaluation = weave.Evaluation(
+        dataset=[{"input_text": "prompt"}],
+        scorers=[
+            make_weave_rai_scorer(_ConfiguredScoreScorer(name="alpha")),
+            make_weave_rai_scorer(_ConfiguredScoreScorer(name="beta")),
+        ],
+    )
+
+    results = await evaluation.get_eval_results(StaticWeaveModel())
+    row = next(iter(results.rows))
+
+    assert set(row["scores"]) == {"alpha", "beta"}
+    assert row["scores"]["alpha"]["score"] == 1.0
+    assert row["scores"]["beta"]["score"] == 0.0
+
+    summary = await evaluation.summarize(results)
+
+    assert summary["alpha"]["score"]["mean"] == 1.0
+    assert summary["beta"]["score"]["mean"] == 0.0


### PR DESCRIPTION
Closes #32.

## Summary

- name each Weave wrapper from the configured RAI scorer name
- retain the scorer class name as a fallback
- prove that two differently named instances of one scorer class keep distinct result and summary keys

## Verification

- the real Weave evaluation collapsed both instances to one class-name key before the fix
- with the Weave extra: 19 passed
- without the Weave extra: 18 passed, 1 skipped
- focused Ruff and format checks passed
- REUSE lint passed
- `git diff --check` passed

AI assistance was used to implement and test this contribution.
