### PR TITLE
fix(examples): preserve falsy values and validate limits

### DIFF
--- a/rai_toolkit/examples/registry.py
+++ b/rai_toolkit/examples/registry.py
@@ -131,7 +131,10 @@ class ExampleRegistry:
             and ``category``.
         """
         desc = ExampleRegistry.get(slug)
-        n = limit if limit is not None else desc.default_limit
+        n = _validate_limit(limit if limit is not None else desc.default_limit)
+
+        if n == 0:
+            return []
 
         if desc.loader is not None:
             rows = desc.loader(n)
@@ -154,10 +157,10 @@ def _normalize_row(row: dict[str, Any], default_category: str) -> dict[str, Any]
     assessable for a row.
     """
     out: dict[str, Any] = {
-        "input_text": str(row.get("input_text") or row.get("question") or row.get("prompt") or ""),
-        "context": str(row.get("context") or row.get("passage") or ""),
-        "expected": str(row.get("expected") or row.get("answer") or row.get("label") or ""),
-        "category": str(row.get("category") or default_category),
+        "input_text": str(_first_present(row, "input_text", "question", "prompt", default="")),
+        "context": str(_first_present(row, "context", "passage", default="")),
+        "expected": str(_first_present(row, "expected", "answer", "label", default="")),
+        "category": str(_first_present(row, "category", default=default_category)),
     }
     rubrics = row.get("rubrics")
     if rubrics:
@@ -165,6 +168,22 @@ def _normalize_row(row: dict[str, Any], default_category: str) -> dict[str, Any]
     if "policy_expectations" in row:
         out["policy_expectations"] = row.get("policy_expectations")
     return out
+
+
+def _first_present(row: dict[str, Any], *keys: str, default: Any) -> Any:
+    """Return the first non-empty alias value without dropping valid falsy data."""
+    for key in keys:
+        value = row.get(key)
+        if value is not None and value != "":
+            return value
+    return default
+
+
+def _validate_limit(limit: Any) -> int:
+    """Validate a dataset row limit before dispatching to any loader."""
+    if isinstance(limit, bool) or not isinstance(limit, int) or limit < 0:
+        raise ValueError("limit must be a non-negative integer")
+    return limit
 
 
 def _load_example_file(filename: str, limit: int) -> list[dict[str, Any]]:

--- a/tests/test_example_registry.py
+++ b/tests/test_example_registry.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Sanath
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+from typing import Any
+
+import pytest
+
+import rai_toolkit.examples.registry as example_registry
+
+
+def test_normalize_row_preserves_falsy_values_without_mutating_input() -> None:
+    row: dict[str, Any] = {
+        "input_text": 0,
+        "question": "fallback question",
+        "context": False,
+        "passage": "fallback passage",
+        "expected": False,
+        "answer": "fallback answer",
+        "category": 0,
+    }
+    original = dict(row)
+
+    normalized = example_registry._normalize_row(row, default_category="MIT-3.1")
+
+    assert normalized == {
+        "input_text": "0",
+        "context": "False",
+        "expected": "False",
+        "category": "0",
+    }
+    assert row == original
+
+
+def test_normalize_row_falls_back_for_missing_none_and_empty_values() -> None:
+    row = {
+        "input_text": "",
+        "question": "fallback question",
+        "context": None,
+        "passage": "fallback passage",
+        "answer": "fallback answer",
+        "category": None,
+    }
+
+    normalized = example_registry._normalize_row(row, default_category="MIT-3.1")
+
+    assert normalized == {
+        "input_text": "fallback question",
+        "context": "fallback passage",
+        "expected": "fallback answer",
+        "category": "MIT-3.1",
+    }
+
+
+def test_load_zero_returns_no_rows_without_invoking_loader(monkeypatch) -> None:
+    calls: list[int] = []
+    descriptor = example_registry.ExampleDescriptor(
+        slug="test-loader",
+        name="Test loader",
+        description="Test fixture",
+        risk_category="MIT-3.1",
+        license="Apache-2.0",
+        reference="Test fixture",
+        loader=lambda limit: calls.append(limit) or [],
+    )
+    monkeypatch.setitem(example_registry.EXAMPLE_CATALOG, descriptor.slug, descriptor)
+
+    assert example_registry.ExampleRegistry.load(descriptor.slug, limit=0) == []
+    assert calls == []
+
+
+@pytest.mark.parametrize("limit", [-1, True])
+def test_load_rejects_negative_and_boolean_limits(monkeypatch, limit: object) -> None:
+    descriptor = example_registry.ExampleDescriptor(
+        slug="test-loader",
+        name="Test loader",
+        description="Test fixture",
+        risk_category="MIT-3.1",
+        license="Apache-2.0",
+        reference="Test fixture",
+        loader=lambda _: [],
+    )
+    monkeypatch.setitem(example_registry.EXAMPLE_CATALOG, descriptor.slug, descriptor)
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        example_registry.ExampleRegistry.load(descriptor.slug, limit=limit)  # type: ignore[arg-type]

--- a/tests/test_example_registry.py
+++ b/tests/test_example_registry.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-PackageName: rai-toolkit
 
+import json
 from typing import Any
 
 import pytest
@@ -69,7 +70,7 @@ def test_load_zero_returns_no_rows_without_invoking_loader(monkeypatch) -> None:
     assert calls == []
 
 
-@pytest.mark.parametrize("limit", [-1, True])
+@pytest.mark.parametrize("limit", [-1, True, False])
 def test_load_rejects_negative_and_boolean_limits(monkeypatch, limit: object) -> None:
     descriptor = example_registry.ExampleDescriptor(
         slug="test-loader",
@@ -84,3 +85,118 @@ def test_load_rejects_negative_and_boolean_limits(monkeypatch, limit: object) ->
 
     with pytest.raises(ValueError, match="non-negative integer"):
         example_registry.ExampleRegistry.load(descriptor.slug, limit=limit)  # type: ignore[arg-type]
+
+
+def test_load_checks_limits_before_the_example_file_backend(monkeypatch, tmp_path) -> None:
+    filename = "example.json"
+    (tmp_path / filename).write_text(
+        json.dumps([{"prompt": "File-backed prompt", "answer": "File-backed answer"}]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(example_registry, "_EXAMPLES_DIR", tmp_path)
+    descriptor = example_registry.ExampleDescriptor(
+        slug="file-backed",
+        name="File-backed fixture",
+        description="Test fixture",
+        risk_category="MIT-3.1",
+        license="Apache-2.0",
+        reference="Test fixture",
+        example_file=filename,
+    )
+    monkeypatch.setitem(example_registry.EXAMPLE_CATALOG, descriptor.slug, descriptor)
+
+    assert example_registry.ExampleRegistry.load(descriptor.slug, limit=1) == [
+        {
+            "input_text": "File-backed prompt",
+            "context": "",
+            "expected": "File-backed answer",
+            "category": "MIT-3.1",
+        }
+    ]
+
+    def fail_if_file_is_read(*_args: object, **_kwargs: object) -> list[dict[str, Any]]:
+        raise AssertionError("the file backend should not run")
+
+    monkeypatch.setattr(example_registry, "_load_example_file", fail_if_file_is_read)
+
+    assert example_registry.ExampleRegistry.load(descriptor.slug, limit=0) == []
+    for invalid_limit in (-1, True, False):
+        with pytest.raises(ValueError, match="non-negative integer"):
+            example_registry.ExampleRegistry.load(descriptor.slug, limit=invalid_limit)
+
+
+def test_load_checks_limits_before_the_generic_huggingface_backend(monkeypatch) -> None:
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def load_dataset(*args: object, **kwargs: object) -> list[dict[str, str]]:
+        calls.append((args, kwargs))
+        return [{"question": "HF prompt", "answer": "HF answer"}]
+
+    monkeypatch.setattr(example_registry, "_require_datasets", lambda: load_dataset)
+    descriptor = example_registry.ExampleDescriptor(
+        slug="generic-huggingface",
+        name="Generic Hugging Face fixture",
+        description="Test fixture",
+        risk_category="MIT-3.1",
+        license="Apache-2.0",
+        reference="Test fixture",
+        huggingface_path="example/dataset:config",
+    )
+    monkeypatch.setitem(example_registry.EXAMPLE_CATALOG, descriptor.slug, descriptor)
+
+    assert example_registry.ExampleRegistry.load(descriptor.slug, limit=1) == [
+        {
+            "input_text": "HF prompt",
+            "context": "",
+            "expected": "HF answer",
+            "category": "MIT-3.1",
+        }
+    ]
+    assert calls == [
+        (("example/dataset", "config"), {"split": "train", "streaming": True})
+    ]
+
+    calls.clear()
+    assert example_registry.ExampleRegistry.load(descriptor.slug, limit=0) == []
+    for invalid_limit in (-1, True, False):
+        with pytest.raises(ValueError, match="non-negative integer"):
+            example_registry.ExampleRegistry.load(descriptor.slug, limit=invalid_limit)
+    assert calls == []
+
+
+def test_load_checks_limits_before_a_registered_streaming_loader(monkeypatch) -> None:
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def load_dataset(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        calls.append((args, kwargs))
+        return [
+            {
+                "question": "Streaming prompt",
+                "best_answer": "Streaming answer",
+                "correct_answers": ["Streaming answer"],
+            }
+        ]
+
+    monkeypatch.setattr(example_registry, "_require_datasets", lambda: load_dataset)
+
+    assert example_registry.ExampleRegistry.load("truthfulqa-gen", limit=1) == [
+        {
+            "input_text": "Streaming prompt",
+            "context": "Accepted truthful answers:\n- Streaming answer",
+            "expected": "Streaming answer",
+            "category": "MIT-3.1",
+        }
+    ]
+    assert calls == [
+        (
+            ("truthfulqa/truthful_qa", "generation"),
+            {"split": "validation", "streaming": True},
+        )
+    ]
+
+    calls.clear()
+    assert example_registry.ExampleRegistry.load("truthfulqa-gen", limit=0) == []
+    for invalid_limit in (-1, True, False):
+        with pytest.raises(ValueError, match="non-negative integer"):
+            example_registry.ExampleRegistry.load("truthfulqa-gen", limit=invalid_limit)
+    assert calls == []


### PR DESCRIPTION
Closes #40

Preserves numeric zero and boolean false when normalizing dataset aliases, while missing, None, and empty values continue to fall through to populated aliases. Validates public load limits before dispatch so zero returns no rows and negative or boolean values raise ValueError.

Tests:
- python -m pytest -q
- python -m ruff check --select E9,F63,F7,F82 rai_toolkit/examples/registry.py tests/test_example_registry.py
- reuse --no-multiprocessing lint

AI-assisted contribution: I used an AI coding assistant during implementation and reviewed the complete diff and test results.