### PR TITLE
docs: use linked draft PRs for contribution claims

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!--
+SPDX-FileCopyrightText: 2026 Karan Nisar
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: rai-toolkit
+-->
+
+## Related issue
+
+Closes #
+
+<!--
+For a substantive change, link the scoped issue with "Closes #NN". Check the
+issue's Development section and open pull requests before starting. A linked
+draft pull request signals that work has started. No /claim comment is needed.
+-->
+
+## What changed
+
+<!--
+Summarize the change and note any behaviour or compatibility considerations.
+-->
+
+## Validation
+
+<!--
+List each local command you ran and its result. In a draft, planned commands are
+fine. Replace them with results before marking the pull request ready.
+-->
+
+- `command`: result
+
+## AI assistance
+
+<!--
+If you used AI assistance, say what it helped with and what you personally
+verified. Remove this section if it does not apply.
+-->
+
+## Checklist
+
+- [ ] I checked the issue's Development section and open pull requests for
+      linked work.
+- [ ] This pull request is focused on one change.
+- [ ] Behavioural changes include tests, or I explained why a test is not
+      needed.
+- [ ] I included the local validation commands and results.
+- [ ] I updated documentation for user-visible changes.
+- [ ] I checked ownership before adding or changing SPDX headers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to rai-toolkit
 
-Bug reports and PRs are welcome. For anything substantive, open an
-[issue](https://github.com/wandb/rai-toolkit/issues) first.
+Bug reports and pull requests are welcome. For a substantive change, start with
+an [issue](https://github.com/wandb/rai-toolkit/issues) so the scope and expected
+behaviour are clear.
 
 ## Setup
 
@@ -10,17 +11,40 @@ python -m venv .venv && source .venv/bin/activate
 pip install -e ".[all]"
 ```
 
+## Starting work
+
+Issues labeled [`status: available`](https://github.com/wandb/rai-toolkit/labels/status%3A%20available)
+have been scoped by a maintainer and are ready for contribution. The label
+describes the readiness of the issue, not whether someone has already started
+working on it.
+
+Before starting, check the issue's Development section and the open pull
+requests for linked work. If an open pull request already addresses the issue,
+join that discussion instead of duplicating the work.
+
+When you begin:
+
+1. Create a branch and open a draft pull request as soon as you have an initial
+   commit.
+2. Add `Closes #NN` to the pull request description.
+3. Briefly describe your approach and the tests you plan to run.
+
+The linked draft pull request is the signal that work has started. You do not
+need to post a `/claim` comment or wait for a status label change. Keep the pull
+request in draft while it is in progress, then mark it ready when the change and
+local validation are complete.
+
 ## Pull request guidelines
 
-- One change per PR.
-- Cover behavioural changes with a test.
-
-## Claiming an issue
-
-- Check the issue thread for an existing claim or linked PR before you start.
-- To claim, comment on the issue that you're working on it, then open your PR when ready. No need to wait for a reply.
-- One PR per issue. When duplicates land, the PR from whoever claimed first gets the review.
-- AI-assisted contributions are fine. Say so in the PR description, and be ready to explain and rework any line when asked.
+- Keep each pull request focused on one change.
+- Link the issue with `Closes #NN` when the pull request resolves it.
+- Explain what changed and call out any behaviour or compatibility
+  considerations.
+- Cover behavioural changes with tests.
+- List the exact local validation commands you ran and their results.
+- Update documentation when user-visible behaviour changes.
+- AI-assisted contributions are fine. Say so in the pull request description,
+  and be ready to explain and rework any line when asked.
 
 ## License headers
 <!--- REUSE-IgnoreStart -->


### PR DESCRIPTION
## What changed

- Replace the manual `/claim` workflow with linked draft pull requests.
- Clarify that `status: available` means a maintainer has scoped the issue and it is ready for contribution.
- Add a pull request template that asks for the linked issue, scope, local validation commands, and results.

## Why

The previous process required a maintainer reply and label change for every contribution. A draft pull request with `Closes #NN` shows the work on the issue directly and removes that manual transition.

This process applies to future contributions. Existing open pull requests and contributor comments are unchanged.

Related to #43.

## Validation

- `git diff --check`: passed
- `reuse --no-multiprocessing lint`: passed, 123 of 123 files compliant
