### PR TITLE
fix(scorers): reject non-finite normalized scores

### DIFF
--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from typing import Any
 
 from openai import OpenAI
@@ -179,6 +180,30 @@ class LLMJudgeScorer(BaseScorer):
         result = self._call_judge(prompts["system"], user_prompt)
 
         raw_score = float(result.get("score", 0))
+        if not math.isfinite(raw_score):
+            logger.warning(
+                "Judge %s returned a non-finite score (%s); marking un-assessed",
+                self.name,
+                raw_score,
+            )
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge returned a non-finite score "
+                    f"({raw_score})."
+                ),
+                details={
+                    "skipped": "non_finite_judge_score",
+                    "scorer_name": self.name,
+                    "raw_score": raw_score,
+                    "max_score": 3,
+                    "judge_model": self.model,
+                    "judge_response": result,
+                },
+                assessed=False,
+            )
         normalized = ScoreNormalizer.from_compliance_scale(raw_score)
         passed = ScoreNormalizer.apply_threshold(normalized, self.threshold)
 
@@ -388,6 +413,31 @@ class GroundednessScorer(LLMJudgeScorer):
         user_prompt = self._format_prompt(output=output, input=input, context=context)
         result = self._call_judge(prompts["system"], user_prompt)
         raw_score = float(result.get("score", 0))
+        if not math.isfinite(raw_score):
+            logger.warning(
+                "Judge %s returned a non-finite score (%s); marking un-assessed",
+                self.name,
+                raw_score,
+            )
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge returned a non-finite score "
+                    f"({raw_score})."
+                ),
+                details={
+                    "skipped": "non_finite_judge_score",
+                    "scorer_name": self.name,
+                    "raw_score": raw_score,
+                    "max_score": 3,
+                    "judge_model": self.model,
+                    "supporting_spans": [],
+                    "contradicting_spans": [],
+                },
+                assessed=False,
+            )
         normalized = ScoreNormalizer.from_compliance_scale(raw_score)
         raw_supporting = result.get("supporting_spans")
         raw_contradicting = result.get("contradicting_spans")

--- a/rai_toolkit/scorers/normalizer.py
+++ b/rai_toolkit/scorers/normalizer.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import math
+
 from rai_toolkit.scorers.base import ScorerResult
 
 
@@ -32,9 +34,19 @@ class ScoreNormalizer:
 
         Returns:
             Normalized score between 0.0 and 1.0.
+
+        Raises:
+            ValueError: If either argument is non-finite, or max_value is not
+                positive. Non-finite values are rejected rather than clamped:
+                ``min(1.0, nan)`` returns ``1.0``, so a malformed judge score
+                would otherwise silently become a perfect, passing score.
         """
+        if not math.isfinite(max_value):
+            raise ValueError(f"max_value must be finite, got {max_value}")
         if max_value <= 0:
             raise ValueError(f"max_value must be positive, got {max_value}")
+        if not math.isfinite(raw_score):
+            raise ValueError(f"raw_score must be finite, got {raw_score}")
         normalized = max(0.0, min(1.0, raw_score / max_value))
         return 1.0 - normalized if invert else normalized
 

--- a/tests/test_score_normalizer.py
+++ b/tests/test_score_normalizer.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2026 Ethan Yeh
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+"""Regression tests for non-finite handling in ScoreNormalizer.
+
+``min(1.0, float("nan"))`` returns ``1.0`` in Python, so an unvalidated
+``NaN`` used to normalize into a perfect score and pass any threshold.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import Mock
+
+import pytest
+
+from rai_toolkit.scorers import FactualityJudge
+from rai_toolkit.scorers.normalizer import ScoreNormalizer
+
+NON_FINITE = [float("nan"), float("inf"), float("-inf")]
+
+
+@pytest.mark.parametrize("raw_score", NON_FINITE)
+def test_from_scale_rejects_non_finite_raw_score(raw_score: float) -> None:
+    with pytest.raises(ValueError, match="raw_score must be finite"):
+        ScoreNormalizer.from_scale(raw_score, max_value=3.0)
+
+
+@pytest.mark.parametrize("max_value", NON_FINITE)
+def test_from_scale_rejects_non_finite_max_value(max_value: float) -> None:
+    with pytest.raises(ValueError, match="max_value must be finite"):
+        ScoreNormalizer.from_scale(1.0, max_value=max_value)
+
+
+@pytest.mark.parametrize("raw_score", NON_FINITE)
+def test_from_scale_rejects_non_finite_when_inverted(raw_score: float) -> None:
+    with pytest.raises(ValueError, match="raw_score must be finite"):
+        ScoreNormalizer.from_scale(raw_score, max_value=3.0, invert=True)
+
+
+@pytest.mark.parametrize("helper", [
+    ScoreNormalizer.from_compliance_scale,
+    ScoreNormalizer.from_likert,
+])
+def test_scale_helpers_reject_nan(helper) -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        helper(float("nan"))
+
+
+def test_non_positive_max_value_still_rejected() -> None:
+    with pytest.raises(ValueError, match="max_value must be positive"):
+        ScoreNormalizer.from_scale(1.0, max_value=0.0)
+
+
+@pytest.mark.parametrize(
+    ("raw_score", "max_value", "expected"),
+    [
+        (0.0, 3.0, 0.0),
+        (1.5, 3.0, 0.5),
+        (3.0, 3.0, 1.0),
+        (9.0, 3.0, 1.0),  # clamped from above
+        (-9.0, 3.0, 0.0),  # clamped from below
+    ],
+)
+def test_finite_values_keep_existing_clamping(
+    raw_score: float, max_value: float, expected: float
+) -> None:
+    assert ScoreNormalizer.from_scale(raw_score, max_value) == expected
+
+
+def test_finite_inversion_is_unchanged() -> None:
+    assert ScoreNormalizer.from_scale(3.0, 3.0, invert=True) == 0.0
+    assert ScoreNormalizer.from_scale(0.0, 3.0, invert=True) == 1.0
+
+
+def test_nan_judge_response_cannot_produce_an_assessed_pass() -> None:
+    """The bug this issue describes, end to end through a judge."""
+    scorer = FactualityJudge(api_key="test", threshold=0.5)
+    scorer._call_judge = Mock(
+        return_value={"score": "NaN", "explanation": "malformed"}
+    )
+
+    result = scorer.score("some output", context="some context")
+
+    assert not result.assessed
+    assert not result.passed
+    assert result.score == 0.0
+    assert result.details["skipped"] == "non_finite_judge_score"
+    assert math.isnan(result.details["raw_score"])
+
+
+@pytest.mark.parametrize("bad_score", ["Infinity", "-Infinity"])
+def test_infinite_judge_response_is_unassessed(bad_score: str) -> None:
+    scorer = FactualityJudge(api_key="test", threshold=0.5)
+    scorer._call_judge = Mock(return_value={"score": bad_score})
+
+    result = scorer.score("some output", context="some context")
+
+    assert not result.assessed
+    assert not result.passed
+    assert result.details["skipped"] == "non_finite_judge_score"
+
+
+def test_finite_judge_response_is_still_assessed() -> None:
+    scorer = FactualityJudge(api_key="test", threshold=0.5)
+    scorer._call_judge = Mock(return_value={"score": 3, "explanation": "good"})
+
+    result = scorer.score("some output", context="some context")
+
+    assert result.assessed
+    assert result.passed
+    assert result.score == 1.0


### PR DESCRIPTION
Closes #38

## Problem

`min(1.0, float("nan"))` returns `1.0` in Python, so `ScoreNormalizer.from_scale()`
clamped a `NaN` raw score into a perfect score:

```python
>>> ScoreNormalizer.from_compliance_scale(float("nan"))
1.0
>>> ScoreNormalizer.apply_threshold(_, 0.7)
True
```

A judge returning `{"score": "NaN"}` therefore produced a passing compliance
result. `max_value` was unguarded for the same reason: `nan <= 0` is `False`,
so a non-finite scale slipped past the existing positivity check.

## Approach

**`normalizer.py`** — validate both arguments at the shared boundary. The finite
check on `max_value` deliberately runs *before* the positivity check, since a
`NaN` would otherwise pass the latter. Clamping and inversion are unchanged for
finite values.

**`llm_judges.py`** — at the two judge call sites, a non-finite raw score now
returns an un-assessed `ScorerResult` instead of propagating the `ValueError`.
`ScorerResult.assessed` already documents "parser failure" as its purpose, and
un-assessed results are excluded from aggregation, so one malformed row neither
inflates a score nor aborts an evaluation run.

### Question on scope

The issue lists only `normalizer.py` and its tests under "Likely files" and says
to keep the change limited to normalization. I touched `llm_judges.py` because
acceptance criterion 4 is about pipeline behaviour, and a bare `ValueError` there
would turn a silent wrong-pass into a crashed evaluation run.

Happy to split that half into a follow-up PR if you would rather keep this one
strictly at the normalization boundary — just say the word.

## Compatibility

`from_scale()` now raises `ValueError` for non-finite input where it previously
returned a clamped value. Any caller deliberately relying on `NaN → 1.0` or
`inf → 1.0` would be affected; within this repo the only callers are the two
judge sites, which are updated here.

## Tests

New `tests/test_score_normalizer.py` (22 cases):

- `NaN`, `+inf`, `-inf` rejected for `raw_score`, `max_value`, and inverted calls
- `from_compliance_scale` / `from_likert` reject `NaN`
- existing clamping, inversion, and the non-positive `max_value` error preserved
- end-to-end: a mocked judge returning `"NaN"` yields `assessed=False`,
  `passed=False`, `score=0.0`
- a finite judge response is still assessed and can still pass

I verified the tests actually catch the bug by reverting the source change and
re-running them: 14 of the 22 fail without the fix.

## Local validation

```
$ python -m pytest -q
42 passed, 3 skipped in 1.18s          # 20 passed, 3 skipped before this change

$ python -m ruff check --select E9,F63,F7,F82 .
All checks passed!

$ reuse --no-multiprocessing lint
Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
109 / 109 files with copyright and license information

$ git diff --check
(no output)
```

Python 3.11.4 on Windows.

## Unrelated observation

While setting up I noticed `rai_toolkit/redteam/attacks.py` is stored in the
repository with CRLF line endings, which contradicts `*.py text eol=lf` in
`.gitattributes`. A fresh `git clone` shows that file as modified immediately,
on a clean checkout with no local edits. It is untouched by this PR — I can open
a separate issue if that is useful.

---

AI-assisted: written with Claude Code. I have reviewed the change and can
explain and rework any line.
