### PR TITLE
fix(scorers): make CompositeScorer honor async and unassessed results

### DIFF
--- a/rai_toolkit/scorers/composite.py
+++ b/rai_toolkit/scorers/composite.py
@@ -66,44 +66,112 @@ class CompositeScorer(BaseScorer):
             result = scorer.score(output=output, input=input, context=context, **kwargs)
             results.append(result)
 
-        # Compute aggregate score
-        aggregate = ScoreNormalizer.aggregate_scores(results, self.weights)
+        return self._combine_results(results)
+
+    async def score_async(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: Any,
+    ) -> ScorerResult:
+        """Asynchronously score each child before combining its result.
+
+        Child scorers run sequentially to preserve the composite's existing
+        execution behaviour; a child can override ``score_async`` for its own
+        asynchronous implementation.
+        """
+        results = []
+        for scorer in self.scorers:
+            result = await scorer.score_async(
+                output=output, input=input, context=context, **kwargs
+            )
+            results.append(result)
+
+        return self._combine_results(results)
+
+    def _combine_results(self, results: list[ScorerResult]) -> ScorerResult:
+        """Build a composite result from child results.
+
+        Un-assessed results are retained in details for coverage reporting but
+        never contribute to the aggregate or pass/fail decision.
+        """
+        assessed_results = [result for result in results if result.assessed]
+        unassessed_count = len(results) - len(assessed_results)
+
+        if not assessed_results:
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category or "composite",
+                explanation="Un-assessed: no child scorers produced a signal.",
+                details=self._details(
+                    results,
+                    aggregate=0.0,
+                    assessed_count=0,
+                    unassessed_count=unassessed_count,
+                ),
+                assessed=False,
+            )
+
+        # Aggregate only assessed results, which also renormalizes weights.
+        aggregate = ScoreNormalizer.aggregate_scores(assessed_results, self.weights)
 
         # Determine pass/fail
         if self.fail_fast:
-            passed = all(r.passed for r in results)
+            passed = all(r.passed for r in assessed_results)
         else:
             passed = ScoreNormalizer.apply_threshold(aggregate, self.threshold)
 
         # Build explanation
-        failed_scorers = [r for r in results if not r.passed]
+        failed_scorers = [r for r in assessed_results if not r.passed]
         if failed_scorers:
             explanations = [
                 f"{r.category}: {r.explanation}" for r in failed_scorers
             ]
             explanation = f"Failed checks: {'; '.join(explanations)}"
         else:
-            explanation = f"All {len(results)} checks passed"
+            explanation = f"All {len(assessed_results)} assessed checks passed"
 
         return ScorerResult(
             score=aggregate,
             passed=passed,
             category=self.category or "composite",
             explanation=explanation,
-            details={
-                "individual_results": [
-                    {
-                        "scorer": scorer.name,
-                        "category": result.category,
-                        "score": result.score,
-                        "passed": result.passed,
-                        "explanation": result.explanation,
-                    }
-                    for scorer, result in zip(self.scorers, results)
-                ],
-                "aggregate_score": aggregate,
-                "scorers_run": len(results),
-                "scorers_passed": sum(1 for r in results if r.passed),
-                "scorers_failed": sum(1 for r in results if not r.passed),
-            },
+            details=self._details(
+                results,
+                aggregate=aggregate,
+                assessed_count=len(assessed_results),
+                unassessed_count=unassessed_count,
+            ),
         )
+
+    def _details(
+        self,
+        results: list[ScorerResult],
+        *,
+        aggregate: float,
+        assessed_count: int,
+        unassessed_count: int,
+    ) -> dict[str, Any]:
+        return {
+            "individual_results": [
+                {
+                    "scorer": scorer.name,
+                    "category": result.category,
+                    "score": result.score,
+                    "passed": result.passed,
+                    "explanation": result.explanation,
+                    "assessed": result.assessed,
+                }
+                for scorer, result in zip(self.scorers, results)
+            ],
+            "aggregate_score": aggregate,
+            "scorers_run": len(results),
+            "scorers_assessed": assessed_count,
+            "scorers_unassessed": unassessed_count,
+            "scorers_passed": sum(1 for r in results if r.assessed and r.passed),
+            "scorers_failed": sum(
+                1 for r in results if r.assessed and not r.passed
+            ),
+        }

--- a/rai_toolkit/scorers/composite.py
+++ b/rai_toolkit/scorers/composite.py
@@ -6,9 +6,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from rai_toolkit.scorers.base import BaseScorer, ScorerResult
+from rai_toolkit.scorers.llm_judges import LLMJudgeScorer
 from rai_toolkit.scorers.normalizer import ScoreNormalizer
 
 
@@ -78,14 +80,23 @@ class CompositeScorer(BaseScorer):
         """Asynchronously score each child before combining its result.
 
         Child scorers run sequentially to preserve the composite's existing
-        execution behaviour; a child can override ``score_async`` for its own
-        asynchronous implementation.
+        execution behaviour. Sync-delegating children run in a worker thread;
+        genuine asynchronous overrides are awaited directly.
         """
         results = []
         for scorer in self.scorers:
-            result = await scorer.score_async(
-                output=output, input=input, context=context, **kwargs
-            )
+            # Match the Weave adapter's handling of the bundled sync delegates.
+            if type(scorer).score_async in {
+                BaseScorer.score_async,
+                LLMJudgeScorer.score_async,
+            }:
+                result = await asyncio.to_thread(
+                    scorer.score, output=output, input=input, context=context, **kwargs
+                )
+            else:
+                result = await scorer.score_async(
+                    output=output, input=input, context=context, **kwargs
+                )
             results.append(result)
 
         return self._combine_results(results)

--- a/tests/test_assessment_weave_additional_scorers.py
+++ b/tests/test_assessment_weave_additional_scorers.py
@@ -18,6 +18,7 @@ import pytest
 from rai_toolkit.assessment import Assessor
 from rai_toolkit.models.base import BaseModel, ModelResponse
 from rai_toolkit.scorers.base import BaseScorer, ScorerResult
+from rai_toolkit.scorers.composite import CompositeScorer
 from rai_toolkit.scorers.llm_judges import LLMJudgeScorer
 
 
@@ -356,8 +357,10 @@ async def test_real_weave_evaluation_awaits_async_additional_scorer(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("composite", [False, True])
 async def test_real_weave_evaluation_keeps_sync_scorers_concurrent(
     monkeypatch: pytest.MonkeyPatch,
+    composite: bool,
 ) -> None:
     pytest.importorskip("weave")
     from rai_toolkit.compliance.frameworks import ComplianceProfile, Framework
@@ -377,14 +380,20 @@ async def test_real_weave_evaluation_keeps_sync_scorers_concurrent(
         model=StubModel(),
         preset="general",
         datasets=["unused"],
-        additional_scorers=[sync_scorer, llm_scorer],
+        additional_scorers=(
+            [CompositeScorer([sync_scorer, llm_scorer], name="composite")]
+            if composite
+            else [sync_scorer, llm_scorer]
+        ),
         use_weave_evaluation=True,
         include_weave_builtin_scorers=False,
     )
 
     result = await assessor._run_evaluation(profile, dataset)
 
-    scorer_names = {"blocking_sync", "blocking_llm_judge"}
+    scorer_names = (
+        {"composite"} if composite else {"blocking_sync", "blocking_llm_judge"}
+    )
     assert result.metadata["evaluation_backend"] == "weave"
     assert set(result.metadata["scorers_used"]) == scorer_names
     assert len(result.items) == len(dataset)

--- a/tests/test_composite_scorer.py
+++ b/tests/test_composite_scorer.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
+from contextvars import ContextVar
 from typing import Any
 
 import pytest
@@ -137,3 +140,52 @@ def test_sync_all_unassessed_results_preserve_coverage_details() -> None:
     assert result.details["scorers_passed"] == 0
     assert result.details["scorers_failed"] == 0
     assert all(not child["assessed"] for child in result.details["individual_results"])
+
+
+@pytest.mark.asyncio
+async def test_async_children_preserve_order_context_and_execution_thread() -> None:
+    caller_thread = threading.get_ident()
+    trace = ContextVar("trace", default="missing")
+    calls: list[tuple[str, int, str]] = []
+
+    class SyncChild(FakeScorer):
+        def score(self, **kwargs: Any) -> ScorerResult:
+            calls.append((self.name, threading.get_ident(), trace.get()))
+            return super().score(**kwargs)
+
+    class AsyncChild(AsyncOnlyScorer):
+        async def score_async(self, **kwargs: Any) -> ScorerResult:
+            await asyncio.sleep(0)
+            calls.append((self.name, threading.get_ident(), trace.get()))
+            return await super().score_async(**kwargs)
+
+    scorers = [
+        SyncChild(_result(1.0, "first"), "first"),
+        AsyncChild(_result(1.0, "second"), "second"),
+        SyncChild(_result(1.0, "third"), "third"),
+    ]
+    token = trace.set("row-context")
+    try:
+        result = await CompositeScorer(scorers).score_async("output")
+    finally:
+        trace.reset(token)
+
+    assert [name for name, _, _ in calls] == ["first", "second", "third"]
+    assert [value for _, _, value in calls] == ["row-context"] * 3
+    assert calls[0][1] != caller_thread
+    assert calls[1][1] == caller_thread
+    assert calls[2][1] != caller_thread
+    assert result.passed
+
+
+@pytest.mark.asyncio
+async def test_async_sync_child_error_stops_later_children() -> None:
+    class FailingChild(FakeScorer):
+        def score(self, **kwargs: Any) -> ScorerResult:
+            raise ValueError("child failed")
+
+    failing = FailingChild(_result(1.0, "first"), "first")
+    later = FakeScorer(_result(1.0, "second"), "second")
+    with pytest.raises(ValueError, match="child failed"):
+        await CompositeScorer([failing, later]).score_async("output")
+    assert later.sync_calls == 0

--- a/tests/test_composite_scorer.py
+++ b/tests/test_composite_scorer.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2026 Yusef Syed
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from rai_toolkit.scorers.base import BaseScorer, ScorerResult
+from rai_toolkit.scorers.composite import CompositeScorer
+
+
+class FakeScorer(BaseScorer):
+    def __init__(self, result: ScorerResult, name: str) -> None:
+        super().__init__(name=name, category=result.category)
+        self.result = result
+        self.sync_calls = 0
+
+    def score(
+        self, output: str, input: str = "", context: str = "", **kwargs: Any
+    ) -> ScorerResult:
+        self.sync_calls += 1
+        return self.result
+
+
+class AsyncOnlyScorer(FakeScorer):
+    def __init__(self, result: ScorerResult, name: str) -> None:
+        super().__init__(result, name)
+        self.async_calls = 0
+
+    def score(
+        self, output: str, input: str = "", context: str = "", **kwargs: Any
+    ) -> ScorerResult:
+        raise AssertionError("CompositeScorer.score_async() must not call score()")
+
+    async def score_async(
+        self, output: str, input: str = "", context: str = "", **kwargs: Any
+    ) -> ScorerResult:
+        self.async_calls += 1
+        return self.result
+
+
+def _result(
+    score: float,
+    category: str,
+    *,
+    passed: bool = True,
+    assessed: bool = True,
+) -> ScorerResult:
+    return ScorerResult(
+        score=score,
+        passed=passed,
+        category=category,
+        explanation=category,
+        assessed=assessed,
+    )
+
+
+@pytest.mark.asyncio
+async def test_score_async_uses_child_async_override_and_renormalizes_weights() -> None:
+    assessed = AsyncOnlyScorer(_result(0.8, "assessed"), "async")
+    unassessed = FakeScorer(
+        _result(0.0, "unassessed", passed=False, assessed=False), "unassessed"
+    )
+    composite = CompositeScorer(
+        [assessed, unassessed], weights={"assessed": 2.0, "unassessed": 98.0}
+    )
+
+    result = await composite.score_async("output")
+
+    assert assessed.async_calls == 1
+    assert result.score == 0.8
+    assert result.passed
+    assert result.assessed
+    assert result.details["scorers_assessed"] == 1
+    assert result.details["scorers_unassessed"] == 1
+
+
+def test_score_excludes_unassessed_results_from_unweighted_aggregation_and_fail_fast() -> None:
+    passing = FakeScorer(_result(0.75, "passing"), "passing")
+    unassessed_failure = FakeScorer(
+        _result(0.0, "not-applicable", passed=False, assessed=False), "unassessed"
+    )
+    composite = CompositeScorer([passing, unassessed_failure], fail_fast=True)
+
+    result = composite.score("output")
+
+    assert passing.sync_calls == 1
+    assert unassessed_failure.sync_calls == 1
+    assert result.score == 0.75
+    assert result.passed
+    assert result.assessed
+    assert "All 1 assessed checks passed" == result.explanation
+
+
+def test_fail_fast_still_applies_to_assessed_failures() -> None:
+    passing = FakeScorer(_result(1.0, "passing"), "passing")
+    failing = FakeScorer(_result(0.0, "failing", passed=False), "failing")
+    composite = CompositeScorer([passing, failing], fail_fast=True)
+
+    result = composite.score("output")
+
+    assert not result.passed
+    assert result.assessed
+    assert result.details["scorers_passed"] == 1
+    assert result.details["scorers_failed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_all_unassessed_results_are_explicitly_unassessed_with_reason() -> None:
+    first = FakeScorer(_result(0.2, "first", assessed=False), "first")
+    second = FakeScorer(_result(0.9, "second", assessed=False), "second")
+    composite = CompositeScorer([first, second])
+
+    result = await composite.score_async("output")
+
+    assert not result.assessed
+    assert not result.passed
+    assert result.score == 0.0
+    assert result.explanation == "Un-assessed: no child scorers produced a signal."
+
+
+def test_sync_all_unassessed_results_preserve_coverage_details() -> None:
+    first = FakeScorer(_result(0.2, "first", assessed=False), "first")
+    second = FakeScorer(_result(0.9, "second", assessed=False), "second")
+    composite = CompositeScorer([first, second])
+
+    result = composite.score("output")
+
+    assert not result.assessed
+    assert not result.passed
+    assert result.details["scorers_run"] == 2
+    assert result.details["scorers_assessed"] == 0
+    assert result.details["scorers_unassessed"] == 2
+    assert result.details["scorers_passed"] == 0
+    assert result.details["scorers_failed"] == 0
+    assert all(not child["assessed"] for child in result.details["individual_results"])


### PR DESCRIPTION
Closes #39.

`CompositeScorer` now honors genuine asynchronous child scorers and excludes unassessed results from aggregation, fail-fast decisions, and pass/fail counts. Weights renormalize over assessed children; a composite with no assessed children remains explicitly unassessed.

Child order stays sequential within each composite. Children inheriting the bundled sync-delegating `BaseScorer.score_async` or `LLMJudgeScorer.score_async` run through `asyncio.to_thread`, while genuine async overrides are awaited directly. This preserves concurrent Weave rows without changing the synchronous `score()` path.

Regression coverage includes weighted/unweighted and unassessed outcomes, mixed sync/async child ordering, execution-thread and context-variable preservation, exception propagation, and parallel composites through the real Weave evaluation adapter. The Weave regression fails on the earlier implementation because each synchronous child reaches only one active call; it passes after the change for both ordinary synchronous scorers and the bundled LLM-judge delegate.

Validation on current main:

- `WANDB_MODE=offline WANDB_SILENT=true .venv/bin/python -m pytest -q`: 66 passed with Weave 0.53.8.
- Focused composite/assessment tests with Weave 0.52.40: 12 passed.
- `.venv/bin/ruff check --select E9,F63,F7,F82 .`: passed.
- Ruff on all three touched files: passed.
- `.venv/bin/reuse --no-multiprocessing lint`: passed.
- `git diff --check`: passed.

AI assistance: AI tools assisted with investigation, implementation, test drafting, review, and validation. The account holder previously confirmed the contribution's ownership and Apache-2.0 submission rights and authorized this contribution and follow-up work. Tests used local fake scorers and offline Weave evaluation; no provider requests were made.
