### PR TITLE
fix(scoping): isolate built-in policies by industry preset

### DIFF
--- a/rai_toolkit/workflow/scoping.py
+++ b/rai_toolkit/workflow/scoping.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from rai_toolkit.assessment import Assessor
 from rai_toolkit.examples import DEMO_EXAMPLE_BUNDLES
 from rai_toolkit.models.base import BaseModel
+from rai_toolkit.policies.engine import PolicyEngine, load_policy_set
 from rai_toolkit.workflow.profile import (
     ApplicationProfile,
     DeploymentContext,
@@ -91,12 +92,63 @@ _DATASET_LIMIT: dict[RiskTier, int | None] = {
     RiskTier.CRITICAL: None,  # full dataset
 }
 
+# These policies apply to every built-in industry preset. Domain-specific
+# additions stay explicit here until first-class policy-pack loading lands.
+_COMMON_BUILTIN_POLICY_FILENAMES = (
+    "eu_ai_act_article_15.yaml",
+    "fairness_baseline.yaml",
+)
+_HEALTHCARE_POLICY_FILENAMES = ("healthcare_hipaa.yaml",)
+
 
 def _resolve_policies_dir(policies_dir: str | Path | None) -> str | None:
     if policies_dir is not None:
         return str(policies_dir)
-    default = Path(__file__).resolve().parents[1] / "policies" / "examples"
-    return str(default) if default.exists() else None
+    return str(_builtin_policy_directory())
+
+
+def _builtin_policy_directory() -> Path:
+    """Return the packaged directory containing built-in policy files."""
+    return Path(__file__).resolve().parents[1] / "policies" / "examples"
+
+
+def _builtin_policy_files(industry: Industry) -> list[Path]:
+    """Return the built-in policy files selected for one industry preset.
+
+    Built-ins are fail-closed: a missing directory, an unclassified YAML file,
+    or a duplicate selection is a packaging/registry error rather than a reason
+    to silently run a reduced policy set.
+    """
+    directory = _builtin_policy_directory()
+    if not directory.is_dir():
+        raise FileNotFoundError(
+            f"Built-in policy directory is missing: {directory}. "
+            "Pass policies_dir explicitly to use a user-supplied policy directory."
+        )
+
+    filenames = list(_COMMON_BUILTIN_POLICY_FILENAMES)
+    if industry is Industry.HEALTHCARE:
+        filenames.extend(_HEALTHCARE_POLICY_FILENAMES)
+
+    if len(filenames) != len(set(filenames)):
+        raise ValueError("Built-in policy registry selects a filename more than once.")
+
+    classified = set(_COMMON_BUILTIN_POLICY_FILENAMES) | set(
+        _HEALTHCARE_POLICY_FILENAMES
+    )
+    available = {path.name for path in directory.glob("*.yaml")}
+    unclassified = sorted(available - classified)
+    if unclassified:
+        raise ValueError(
+            "Built-in policy registry does not classify: " + ", ".join(unclassified)
+        )
+
+    missing = sorted(classified - available)
+    if missing:
+        raise FileNotFoundError(
+            "Built-in policy registry references missing file(s): " + ", ".join(missing)
+        )
+    return [directory / filename for filename in filenames]
 
 
 def _effective_risk_tier(
@@ -216,8 +268,22 @@ def scope_assessor(
     )
 
     resolved_policies = _resolve_policies_dir(policies_dir)
-    if resolved_policies:
-        rationale.append(f"Policies loaded from `{resolved_policies}`.")
+    policies_engine: PolicyEngine | None = None
+    if policies_dir is not None:
+        # A caller-selected directory is a complete override: its files are
+        # loaded exactly as supplied, without mixing in or filtering built-ins.
+        if resolved_policies:
+            rationale.append(
+                f"Policies loaded from user-supplied `{resolved_policies}`."
+            )
+    else:
+        policy_files = _builtin_policy_files(profile.industry)
+        policies_engine = PolicyEngine([load_policy_set(path) for path in policy_files])
+        rationale.append(
+            "Built-in policy files selected: "
+            + ", ".join(f"`{path.name}`" for path in policy_files)
+            + "."
+        )
 
     if profile.weave_project:
         rationale.append(
@@ -230,7 +296,8 @@ def scope_assessor(
         model=model,
         preset=preset,
         datasets=datasets,
-        policies_dir=resolved_policies,
+        policies_dir=resolved_policies if policies_dir is not None else None,
+        policies_engine=policies_engine,
         run_redteam=run_redteam,
         redteam_max_severity=severity_cap,
         extra_redteam_sources=list(profile.extra_redteam_sources),

--- a/tests/test_policy_scoping.py
+++ b/tests/test_policy_scoping.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: 2026 Yusef Syed
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+"""Offline regression coverage for built-in policy selection by preset."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from rai_toolkit.models.base import BaseModel, ModelResponse
+from rai_toolkit.workflow import ApplicationProfile, Industry, scope_assessor, scoping
+
+
+class FakeModel(BaseModel):
+    """Deterministic model fixture; it never makes a network request."""
+
+    async def predict(
+        self,
+        input_text: str,
+        context: str = "",
+        **kwargs: object,
+    ) -> ModelResponse:
+        del input_text, context, kwargs
+        return ModelResponse(output="The diagnosis is uncertain.")
+
+
+def _profile(industry: Industry) -> ApplicationProfile:
+    return ApplicationProfile(
+        name="Scoped assistant",
+        description="Offline policy-selection test fixture",
+        owner_team="rai",
+        owner_email="rai@example.com",
+        industry=industry,
+        dataset_overrides=["finqa-sample"],
+    )
+
+
+def _content_violations(assessor: object, model: FakeModel) -> set[str]:
+    output = asyncio.run(model.predict("Summarize this loan file.")).output
+    engine = assessor.policies_engine  # type: ignore[attr-defined]
+    assert engine is not None
+    return {
+        violation.policy_name
+        for violation in engine.evaluate(
+            [], model_output=output, model_input="Summarize this loan file."
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    ("industry", "expected_policy_sets", "expected_filenames"),
+    [
+        (
+            Industry.FINANCIAL_SERVICES,
+            [
+                "EU AI Act - Article 15 (Accuracy, Robustness, Cybersecurity)",
+                "Fairness Baseline",
+            ],
+            ["eu_ai_act_article_15.yaml", "fairness_baseline.yaml"],
+        ),
+        (
+            Industry.HR,
+            [
+                "EU AI Act - Article 15 (Accuracy, Robustness, Cybersecurity)",
+                "Fairness Baseline",
+            ],
+            ["eu_ai_act_article_15.yaml", "fairness_baseline.yaml"],
+        ),
+        (
+            Industry.GOVERNMENT,
+            [
+                "EU AI Act - Article 15 (Accuracy, Robustness, Cybersecurity)",
+                "Fairness Baseline",
+            ],
+            ["eu_ai_act_article_15.yaml", "fairness_baseline.yaml"],
+        ),
+        (
+            Industry.GENERAL,
+            [
+                "EU AI Act - Article 15 (Accuracy, Robustness, Cybersecurity)",
+                "Fairness Baseline",
+            ],
+            ["eu_ai_act_article_15.yaml", "fairness_baseline.yaml"],
+        ),
+        (
+            Industry.HEALTHCARE,
+            [
+                "EU AI Act - Article 15 (Accuracy, Robustness, Cybersecurity)",
+                "Fairness Baseline",
+                "Healthcare / HIPAA Safeguards",
+            ],
+            [
+                "eu_ai_act_article_15.yaml",
+                "fairness_baseline.yaml",
+                "healthcare_hipaa.yaml",
+            ],
+        ),
+    ],
+)
+def test_built_in_presets_select_exact_policy_sets(
+    industry: Industry,
+    expected_policy_sets: list[str],
+    expected_filenames: list[str],
+) -> None:
+    assessor, decision = scope_assessor(_profile(industry), FakeModel())
+
+    assert assessor.policies_engine is not None
+    assert [
+        policy_set.name for policy_set in assessor.policies_engine.policy_sets
+    ] == expected_policy_sets
+    assert (
+        "Built-in policy files selected: "
+        + ", ".join(f"`{filename}`" for filename in expected_filenames)
+        + "."
+    ) in decision.rationale
+
+
+@pytest.mark.parametrize(
+    "industry",
+    [Industry.FINANCIAL_SERVICES, Industry.HR, Industry.GOVERNMENT, Industry.GENERAL],
+)
+def test_non_healthcare_presets_cannot_fire_healthcare_policies(
+    industry: Industry,
+) -> None:
+    model = FakeModel()
+    assessor, decision = scope_assessor(_profile(industry), model)
+
+    assert "medical-disclaimer-required" not in _content_violations(assessor, model)
+    assert not any("healthcare_hipaa.yaml" in reason for reason in decision.rationale)
+
+
+def test_healthcare_keeps_and_records_its_healthcare_policy() -> None:
+    model = FakeModel()
+    assessor, decision = scope_assessor(_profile(Industry.HEALTHCARE), model)
+
+    assert "medical-disclaimer-required" in _content_violations(assessor, model)
+    assert any("healthcare_hipaa.yaml" in reason for reason in decision.rationale)
+
+
+def test_explicit_policies_dir_is_a_complete_unfiltered_override(
+    tmp_path: Path,
+) -> None:
+    custom_policy = tmp_path / "custom.yaml"
+    custom_policy.write_text(
+        """\
+name: Custom policies
+description: Explicit policy directory fixture
+version: \"1.0.0\"
+policies:
+  - name: custom-only-rule
+    description: Custom rule
+    severity: high
+    trigger:
+      output_contains: [diagnosis]
+    frameworks: [Custom]
+    remediation: Review custom policy.
+""",
+        encoding="utf-8",
+    )
+    model = FakeModel()
+    assessor, decision = scope_assessor(
+        _profile(Industry.FINANCIAL_SERVICES), model, policies_dir=tmp_path
+    )
+
+    assert decision.policies_dir == str(tmp_path)
+    assert assessor.policies_engine is not None
+    assert [policy_set.name for policy_set in assessor.policies_engine.policy_sets] == [
+        "Custom policies"
+    ]
+    assert _content_violations(assessor, model) == {"custom-only-rule"}
+
+
+def test_implicit_built_ins_fail_closed_when_their_directory_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    missing_directory = tmp_path / "missing"
+    monkeypatch.setattr(scoping, "_builtin_policy_directory", lambda: missing_directory)
+
+    with pytest.raises(FileNotFoundError, match="Built-in policy directory is missing"):
+        scope_assessor(_profile(Industry.GENERAL), FakeModel())
+
+
+def test_implicit_built_ins_fail_closed_for_an_unclassified_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_directory = (
+        Path(scoping.__file__).resolve().parents[1] / "policies" / "examples"
+    )
+    for policy in source_directory.glob("*.yaml"):
+        (tmp_path / policy.name).write_text(
+            policy.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+    (tmp_path / "future_policy.yaml").write_text("name: future", encoding="utf-8")
+    monkeypatch.setattr(scoping, "_builtin_policy_directory", lambda: tmp_path)
+
+    with pytest.raises(ValueError, match="future_policy.yaml"):
+        scope_assessor(_profile(Industry.GENERAL), FakeModel())
+
+
+def test_implicit_built_ins_fail_closed_for_a_missing_registered_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_directory = (
+        Path(scoping.__file__).resolve().parents[1] / "policies" / "examples"
+    )
+    for policy in source_directory.glob("*.yaml"):
+        if policy.name != "healthcare_hipaa.yaml":
+            (tmp_path / policy.name).write_text(
+                policy.read_text(encoding="utf-8"), encoding="utf-8"
+            )
+    monkeypatch.setattr(scoping, "_builtin_policy_directory", lambda: tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="healthcare_hipaa.yaml"):
+        scope_assessor(_profile(Industry.GENERAL), FakeModel())
+
+
+def test_implicit_built_ins_fail_closed_for_duplicate_registry_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        scoping,
+        "_COMMON_BUILTIN_POLICY_FILENAMES",
+        ("eu_ai_act_article_15.yaml", "eu_ai_act_article_15.yaml"),
+    )
+
+    with pytest.raises(ValueError, match="selects a filename more than once"):
+        scope_assessor(_profile(Industry.GENERAL), FakeModel())
+
+
+def test_default_profile_uses_the_general_built_in_selection() -> None:
+    profile = ApplicationProfile(
+        name="Default assistant",
+        description="Uses ApplicationProfile defaults",
+        owner_team="rai",
+        owner_email="rai@example.com",
+        dataset_overrides=["finqa-sample"],
+    )
+
+    assessor, decision = scope_assessor(profile, FakeModel())
+
+    assert decision.preset == "general"
+    assert assessor.policies_engine is not None
+    assert [policy_set.name for policy_set in assessor.policies_engine.policy_sets] == [
+        "EU AI Act - Article 15 (Accuracy, Robustness, Cybersecurity)",
+        "Fairness Baseline",
+    ]
+
+
+def test_explicit_examples_directory_remains_unfiltered_for_finance() -> None:
+    examples_directory = (
+        Path(scoping.__file__).resolve().parents[1] / "policies" / "examples"
+    )
+
+    assessor, decision = scope_assessor(
+        _profile(Industry.FINANCIAL_SERVICES),
+        FakeModel(),
+        policies_dir=examples_directory,
+    )
+
+    assert decision.policies_dir == str(examples_directory)
+    assert assessor.policies_engine is not None
+    assert [policy_set.name for policy_set in assessor.policies_engine.policy_sets] == [
+        "EU AI Act - Article 15 (Accuracy, Robustness, Cybersecurity)",
+        "Fairness Baseline",
+        "Healthcare / HIPAA Safeguards",
+    ]
+
+
+def test_explicit_empty_directory_remains_an_empty_complete_override(
+    tmp_path: Path,
+) -> None:
+    assessor, decision = scope_assessor(
+        _profile(Industry.GENERAL), FakeModel(), policies_dir=tmp_path
+    )
+
+    assert decision.policies_dir == str(tmp_path)
+    assert assessor.policies_engine is not None
+    assert assessor.policies_engine.policy_sets == []
+
+
+def test_explicit_missing_directory_preserves_assessor_error(tmp_path: Path) -> None:
+    with pytest.raises(NotADirectoryError):
+        scope_assessor(
+            _profile(Industry.GENERAL),
+            FakeModel(),
+            policies_dir=tmp_path / "missing",
+        )


### PR DESCRIPTION
## Related issue

Closes #23

## What changed

- Select the EU AI Act Article 15 and fairness policy files for every implicit
  built-in industry scope.
- Add the healthcare/HIPAA policy file only for the healthcare preset, preventing
  finance, HR, government, and general scopes from firing healthcare-only
  deterministic rules.
- Preserve an explicit `policies_dir` as a complete, unfiltered user override;
  built-ins are neither mixed into nor filtered out of that directory.
- Record the selected built-in filenames in the scoping rationale.
- Fail closed when the packaged built-in directory is missing, a registered file
  is absent, a YAML file is unclassified, or a selected filename is duplicated.
- Add deterministic offline regressions for all five presets, healthcare and
  finance behavior, default-general behavior, explicit custom/full/empty/missing
  directories, and registry failure modes.

Compatibility: `scope_assessor()` keeps its existing signature. Direct
`Assessor` and CLI behavior are unchanged; first-class policy packs remain out
of scope as specified by the issue.

## Validation

- `uv run pytest tests/test_policy_scoping.py -q`: 19 passed
- `uv run pytest -q`: 39 passed, 3 skipped
- `uv run python -m compileall -q rai_toolkit tests`: passed
- scoped Ruff and formatting checks: passed (excluding the pre-existing
  `ISC004` finding at the existing adjacent string literal)
- `uvx --from 'reuse[charset-normalizer]' reuse lint`: REUSE 3.3 compliant
- `git diff --check`: passed
- `uv build ...`: wheel and sdist built successfully
- clean CPython 3.12 wheel install, invoked outside the source tree with an empty
  `PYTHONPATH`: passed
- installed-wheel `scope_assessor()` smoke: finance selected exactly EU+fairness
  and did not fire `medical-disclaimer-required`; healthcare selected
  EU+fairness+HIPAA and did fire the rule
- wheel and sdist contents: exactly the three registered built-in YAML policy
  assets are present

## AI assistance

AI tools assisted with issue analysis, implementation and test drafting,
line-level review, architecture review, hardening, and validation. The account
holder confirmed the contribution's copyright and Apache-2.0 submission rights.
The account holder reviewed and approved the final two-file diff and validation
evidence on 2026-09-04.

## Checklist

- [x] I checked the issue's Development section and open pull requests for
      linked work.
- [x] This pull request is focused on one change.
- [x] Behavioural changes include deterministic offline tests.
- [x] I included the completed validation accurately.
- [x] No separate documentation change is proposed; the selected built-in files
      are surfaced in the existing scoping rationale and the issue defines the
      compatibility contract.
- [x] I checked ownership before adding the new test-file SPDX header.
