### PR TITLE
feat(models): add Anthropic Messages API adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ pip install -e ".[pyrit]"
 # Garak red-team integration
 pip install -e ".[garak]"
 
+# Anthropic Messages API model adapter
+pip install -e ".[anthropic]"
+
 # Everything (incl. demo Streamlit app + dev tooling)
 pip install -e ".[all]"
 ```
@@ -304,6 +307,46 @@ git URL (e.g. `git+https://github.com/wandb/rai-toolkit.git@v0.1.0`).
 
 The Python import path is `rai_toolkit` (e.g. `from rai_toolkit import Assessor`)
 regardless of which install method you use.
+
+### Model adapters
+
+The toolkit ships vendor-neutral model adapters under `rai_toolkit.models`.
+Both expose a shared `BaseModel` / `ModelResponse` contract, so you can swap
+providers without changing your assessment code.
+
+```bash
+# Anthropic Messages API adapter (optional extra)
+pip install -e ".[anthropic]"
+```
+
+```python
+import asyncio
+
+from rai_toolkit.models import AnthropicModel
+
+
+async def main() -> None:
+    model = AnthropicModel(
+        model="claude-sonnet-4-5",
+        # No api_key? The Anthropic SDK falls back to ANTHROPIC_API_KEY.
+        system_prompt="You are a triage assistant.",
+        max_tokens=1024,  # positive default; override per call below
+    )
+    result = await model.predict(
+        "Review this answer.",
+        context="Retrieved policy text",
+        max_tokens=2048,
+    )
+    print(result.output)
+    print(result.metadata)
+
+
+asyncio.run(main())
+```
+
+The optional key is never substituted: when `api_key` is omitted, key
+resolution is left entirely to the Anthropic SDK (e.g. the
+`ANTHROPIC_API_KEY` environment variable).
 
 Running fully self-hosted or air-gapped? See [docs/self_hosted.md](docs/self_hosted.md).
 
@@ -465,7 +508,7 @@ rai_toolkit/
   assessment/         End-to-end Assessor workflow + HTML report
   workflow/              Review gate: profile, scoping, submission,
                          decisions, ManualFinding from interactive probing
-  models/                BaseModel + OpenAI-compatible adapter
+  models/                BaseModel + OpenAI-compatible + Anthropic adapters
   cli.py                 `rai` command
 
 integrations/
@@ -521,6 +564,7 @@ documents the licenses declared by each dependency in `pyproject.toml`.
 | [nemoguardrails](https://github.com/NVIDIA/NeMo-Guardrails) | 0.21.0 | Apache-2.0 | `nemo` |
 | [pyrit](https://github.com/microsoft/PyRIT) | 0.13.0 | MIT | `pyrit` |
 | [garak](https://github.com/NVIDIA/garak) | 0.15.0 | Apache-2.0 | `garak` |
+| [anthropic](https://github.com/anthropics/anthropic-sdk-python) | 0.40.0 | MIT | `anthropic` |
 | [torchvision](https://github.com/pytorch/vision) | 0.20.0 | BSD-3-Clause | `garak` |
 | [streamlit](https://github.com/streamlit/streamlit) | 1.57.0 | Apache-2.0 | `demo` |
 | [plotly](https://github.com/plotly/plotly.py) | 6.0.0 | MIT | `demo` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ garak = [
     # attribute walk.
     "torchvision>=0.20.0",
 ]
+anthropic = [
+    "anthropic>=0.40.0",
+]
 demo = [
     "streamlit>=1.57.0",
     "plotly>=6.0.0",
@@ -83,7 +86,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
 ]
 all = [
-    "rai-toolkit[weave,scorers,nemo,demo,dev,datasets,pyrit,garak]",
+    "rai-toolkit[weave,scorers,nemo,demo,dev,datasets,pyrit,garak,anthropic]",
 ]
 
 [project.urls]

--- a/rai_toolkit/models/__init__.py
+++ b/rai_toolkit/models/__init__.py
@@ -4,7 +4,8 @@
 
 """Model abstractions: platform-agnostic model interface."""
 
+from rai_toolkit.models.anthropic import AnthropicModel
 from rai_toolkit.models.base import BaseModel, ModelResponse
 from rai_toolkit.models.openai_compatible import OpenAICompatibleModel
 
-__all__ = ["BaseModel", "ModelResponse", "OpenAICompatibleModel"]
+__all__ = ["AnthropicModel", "BaseModel", "ModelResponse", "OpenAICompatibleModel"]

--- a/rai_toolkit/models/anthropic.py
+++ b/rai_toolkit/models/anthropic.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2026 schallten
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+"""Anthropic Messages API model adapter.
+
+Wraps Anthropic's asynchronous Python client behind the toolkit's vendor-
+neutral :class:`~rai_toolkit.models.base.BaseModel`. The ``anthropic``
+package is an optional dependency (the ``[anthropic]`` extra) and is
+imported lazily so that ``rai_toolkit`` and ``rai_toolkit.models`` keep
+working in environments that don't have it installed.
+
+Build one directly or via :func:`from_args`, a configuration helper for
+callers that work from flat dicts or form payloads.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from rai_toolkit.models.base import BaseModel, ModelResponse
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_TOKENS = 1024
+
+_ANTHROPIC_IMPORT_ERROR = (
+    "The 'anthropic' package is required to use AnthropicModel. "
+    "Install it with: pip install -e '.[anthropic]'"
+)
+
+
+def _coerce_max_tokens(value: Any) -> int:
+    """Normalize ``max_tokens`` across every entry point.
+
+    ``None`` and blank strings fall back to :data:`DEFAULT_MAX_TOKENS`.
+    Anything else must be a strict positive integer: booleans, floats,
+    and non-integer strings are rejected.
+    """
+    if value is None:
+        return DEFAULT_MAX_TOKENS
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped == "":
+            return DEFAULT_MAX_TOKENS
+        if not stripped.lstrip("+-").isdigit():
+            raise ValueError(f"max_tokens must be a positive integer, got {value!r}")
+        value = int(stripped)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"max_tokens must be a positive integer, got {value!r}")
+    return value
+
+
+class AnthropicModel(BaseModel):
+    """A ``BaseModel`` backed by Anthropic's Messages API.
+
+    Args:
+        model: Anthropic model identifier (``claude-sonnet-4-5``, etc.).
+        api_key: API key. When omitted, resolution is left to the Anthropic
+            SDK (``ANTHROPIC_API_KEY`` env var). No fallback key is
+            invented.
+        base_url: Optional override for the Anthropic client (proxies /
+            compatible gateways). Leave ``None`` for the Anthropic API.
+        system_prompt: Optional system message prepended to every call.
+            This is how a triage-assistant or RAG-style app wires its
+            system instructions while still being a generic adapter.
+        max_tokens: Default maximum number of tokens to generate. Must be
+            a strict positive integer; ``None`` resets it to the
+            documented default. Override per-call via
+            ``predict(..., max_tokens=...)``.
+        name: Display name shown in reports / logs. Defaults to the model
+            id.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        system_prompt: str | None = None,
+        max_tokens: int | None = DEFAULT_MAX_TOKENS,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name or model)
+        self.model = model
+        self.api_key = api_key
+        self.base_url = base_url
+        self.system_prompt = system_prompt
+        self.max_tokens = _coerce_max_tokens(max_tokens)
+        self._client: Any = None
+
+    @property
+    def client(self) -> Any:
+        """The lazily-created ``AsyncAnthropic`` client."""
+        if self._client is None:
+            try:
+                from anthropic import AsyncAnthropic
+            except ImportError as exc:  # pragma: no cover - absent only without the extra
+                raise ImportError(_ANTHROPIC_IMPORT_ERROR) from exc
+
+            client_kwargs: dict[str, Any] = {}
+            if self.api_key is not None:
+                client_kwargs["api_key"] = self.api_key
+            if self.base_url is not None:
+                client_kwargs["base_url"] = self.base_url
+            self._client = AsyncAnthropic(**client_kwargs)
+        return self._client
+
+    async def predict(
+        self,
+        input_text: str,
+        context: str = "",
+        **kwargs: Any,
+    ) -> ModelResponse:
+        """Run inference against Anthropic's Messages API.
+
+        Args:
+            input_text: The user input or query. Sent as the user message.
+            context: Optional retrieved context (for RAG systems). Sent
+                through the top-level ``system`` parameter alongside the
+                system prompt.
+            **kwargs: ``max_tokens`` overrides the adapter default for this
+                call. Must be positive when provided.
+
+        Returns:
+            ModelResponse with all text blocks concatenated into ``output``
+            and normalized metadata.
+        """
+        max_tokens = _coerce_max_tokens(kwargs.get("max_tokens", self.max_tokens))
+
+        system_parts: list[str] = []
+        if self.system_prompt:
+            system_parts.append(self.system_prompt)
+        if context:
+            system_parts.append(f"Retrieved context:\n{context}")
+
+        params: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": input_text}],
+        }
+        if system_parts:
+            params["system"] = "\n\n".join(system_parts)
+
+        response = await self.client.messages.create(**params)
+
+        text_blocks = [
+            block.text
+            for block in response.content
+            if getattr(block, "type", None) == "text"
+        ]
+        usage = getattr(response, "usage", None)
+        prompt_tokens = getattr(usage, "input_tokens", None)
+        completion_tokens = getattr(usage, "output_tokens", None)
+        if prompt_tokens is not None and completion_tokens is not None:
+            total_tokens = prompt_tokens + completion_tokens
+        else:
+            total_tokens = None
+
+        return ModelResponse(
+            output="".join(text_blocks),
+            metadata={
+                "model": self.model,
+                "base_url": self.base_url,
+                "finish_reason": getattr(response, "stop_reason", None),
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+            },
+        )
+
+
+def from_args(args: dict[str, Any]) -> AnthropicModel:
+    """Build an adapter from a flat configuration dict.
+
+    Requires a ``model`` key. Optional keys (``api_key``, ``base_url``,
+    ``system_prompt``, ``max_tokens``, ``name``) are treated as unset when
+    missing or empty. ``max_tokens`` accepts an int or an integer-literal
+    string; ``None`` and blank values fall back to
+    :data:`DEFAULT_MAX_TOKENS`.
+    """
+    if not args.get("model"):
+        raise ValueError("AnthropicModel requires a 'model' argument")
+    return AnthropicModel(
+        model=args["model"],
+        api_key=args.get("api_key") or None,
+        base_url=args.get("base_url") or None,
+        system_prompt=args.get("system_prompt") or None,
+        max_tokens=_coerce_max_tokens(args.get("max_tokens")),
+        name=args.get("name") or None,
+    )

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: 2026 schallten
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+from typing import Any, ClassVar
+
+import pytest
+
+import rai_toolkit.models as models_pkg
+from rai_toolkit.models import AnthropicModel
+from rai_toolkit.models import anthropic as anthropic_module
+
+anthropic = pytest.importorskip("anthropic")
+
+
+class FakeMessages:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="offline answer")],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=7, output_tokens=3),
+        )
+
+
+class FakeAsyncAnthropic:
+    instances: ClassVar[list[FakeAsyncAnthropic]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.messages = FakeMessages()
+        self.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def fake_anthropic_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeAsyncAnthropic.instances.clear()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", FakeAsyncAnthropic)
+
+
+def latest_client() -> FakeAsyncAnthropic:
+    assert len(FakeAsyncAnthropic.instances) == 1
+    return FakeAsyncAnthropic.instances[0]
+
+
+def test_client_receives_explicit_credentials() -> None:
+    model = AnthropicModel(
+        model="claude-sonnet-4-5",
+        base_url="https://proxy.example/v1",
+        api_key="secret-test-key",
+    )
+
+    assert model.name == "claude-sonnet-4-5"
+    assert model.client.kwargs == {
+        "api_key": "secret-test-key",
+        "base_url": "https://proxy.example/v1",
+    }
+
+
+def test_client_leaves_key_resolution_to_anthropic_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "environment-key")
+
+    model = AnthropicModel(model="claude-sonnet-4-5")
+
+    assert model.client.kwargs == {}
+
+
+def test_default_max_tokens_is_documented_and_positive() -> None:
+    model = AnthropicModel(model="claude-sonnet-4-5")
+
+    assert model.max_tokens == anthropic_module.DEFAULT_MAX_TOKENS
+    assert model.max_tokens > 0
+
+
+@pytest.mark.parametrize("bad", [0, -3, True, 1.5, 2.0, "abc", "1.5"])
+def test_constructor_rejects_invalid_max_tokens(bad: Any) -> None:
+    with pytest.raises(ValueError, match="max_tokens"):
+        AnthropicModel(model="claude-sonnet-4-5", max_tokens=bad)
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_constructor_uses_documented_default_for_none_or_blank(value: Any) -> None:
+    model = AnthropicModel(model="claude-sonnet-4-5", max_tokens=value)
+
+    assert model.max_tokens == anthropic_module.DEFAULT_MAX_TOKENS
+
+
+async def test_predict_builds_system_and_context_through_top_level_system() -> None:
+    model = AnthropicModel(
+        model="claude-sonnet-4-5",
+        base_url="https://proxy.example/v1",
+        system_prompt="Follow the policy.",
+        max_tokens=512,
+        name="Claude reviewer",
+    )
+
+    response = await model.predict("Review this answer.", context="Policy text")
+
+    assert model.name == "Claude reviewer"
+    (call,) = latest_client().messages.calls
+    assert call["model"] == "claude-sonnet-4-5"
+    assert call["max_tokens"] == 512
+    assert call["system"] == "Follow the policy.\n\nRetrieved context:\nPolicy text"
+    assert call["messages"] == [{"role": "user", "content": "Review this answer."}]
+    assert response.output == "offline answer"
+
+
+async def test_predict_omits_system_param_when_unset() -> None:
+    model = AnthropicModel(model="claude-sonnet-4-5")
+
+    await model.predict("Review this answer.")
+
+    (call,) = latest_client().messages.calls
+    assert "system" not in call
+    assert call["max_tokens"] == anthropic_module.DEFAULT_MAX_TOKENS
+
+
+async def test_predict_overrides_max_tokens_per_call() -> None:
+    model = AnthropicModel(model="claude-sonnet-4-5", max_tokens=128)
+
+    await model.predict("Review this answer.", max_tokens=2048)
+
+    (call,) = latest_client().messages.calls
+    assert call["max_tokens"] == 2048
+
+
+@pytest.mark.parametrize("bad", [0, -3, True, 1.5, "abc", "1.5"])
+async def test_predict_rejects_invalid_per_call_max_tokens(bad: Any) -> None:
+    model = AnthropicModel(model="claude-sonnet-4-5")
+
+    with pytest.raises(ValueError, match="max_tokens"):
+        await model.predict("Review this answer.", max_tokens=bad)
+
+
+async def test_predict_uses_documented_default_for_none_override() -> None:
+    model = AnthropicModel(model="claude-sonnet-4-5", max_tokens=512)
+
+    await model.predict("Review this answer.", max_tokens=None)
+
+    (call,) = latest_client().messages.calls
+    assert call["max_tokens"] == anthropic_module.DEFAULT_MAX_TOKENS
+
+
+async def test_predict_concatenates_text_blocks_without_invented_separator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def multi_block_create(self: Any, **kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(
+            content=[
+                SimpleNamespace(type="text", text="first"),
+                SimpleNamespace(type="tool_use", text="ignored"),
+                SimpleNamespace(type="text", text="second"),
+            ],
+            stop_reason="max_tokens",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+
+    monkeypatch.setattr(FakeMessages, "create", multi_block_create)
+
+    model = AnthropicModel(model="claude-sonnet-4-5")
+    response = await model.predict("Review this answer.")
+
+    assert response.output == "firstsecond"
+
+
+async def test_predict_normalizes_metadata() -> None:
+    model = AnthropicModel(
+        model="claude-sonnet-4-5",
+        base_url="https://proxy.example/v1",
+    )
+
+    response = await model.predict("Review this answer.")
+
+    assert response.metadata == {
+        "model": "claude-sonnet-4-5",
+        "base_url": "https://proxy.example/v1",
+        "finish_reason": "end_turn",
+        "prompt_tokens": 7,
+        "completion_tokens": 3,
+        "total_tokens": 10,
+    }
+
+
+async def test_predict_handles_missing_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def no_usage_create(self: Any, **kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="offline answer")],
+            stop_reason="end_turn",
+            usage=None,
+        )
+
+    monkeypatch.setattr(FakeMessages, "create", no_usage_create)
+
+    model = AnthropicModel(model="claude-sonnet-4-5")
+    response = await model.predict("Review this answer.")
+
+    assert response.output == "offline answer"
+    assert response.metadata["prompt_tokens"] is None
+    assert response.metadata["completion_tokens"] is None
+    assert response.metadata["total_tokens"] is None
+
+
+def test_from_args_requires_model() -> None:
+    with pytest.raises(ValueError, match="model"):
+        anthropic_module.from_args({})
+
+
+def test_from_args_converts_and_validates() -> None:
+    model = anthropic_module.from_args(
+        {
+            "model": "claude-sonnet-4-5",
+            "base_url": "https://proxy.example/v1",
+            "api_key": "configured-key",
+            "system_prompt": "Be concise.",
+            "max_tokens": "4000",
+            "name": "Claude reviewer",
+        }
+    )
+
+    assert model.name == "Claude reviewer"
+    assert model.max_tokens == 4000
+    assert model.client.kwargs == {
+        "api_key": "configured-key",
+        "base_url": "https://proxy.example/v1",
+    }
+
+
+def test_from_args_treats_empty_optionals_as_unset() -> None:
+    model = anthropic_module.from_args(
+        {
+            "model": "claude-sonnet-4-5",
+            "base_url": "",
+            "api_key": "",
+            "system_prompt": "",
+            "max_tokens": "1024",
+            "name": "",
+        }
+    )
+
+    assert model.name == "claude-sonnet-4-5"
+    assert model.base_url is None
+    assert model.system_prompt is None
+    assert model.client.kwargs == {}
+
+
+def test_from_args_uses_documented_default_for_none_or_blank() -> None:
+    for value in [None, "", "   "]:
+        model = anthropic_module.from_args(
+            {"model": "claude-sonnet-4-5", "max_tokens": value}
+        )
+
+        assert model.max_tokens == anthropic_module.DEFAULT_MAX_TOKENS
+
+
+@pytest.mark.parametrize("bad", [True, 1.5, "1.5", "abc", 0, "0"])
+def test_from_args_rejects_non_integer_max_tokens(bad: Any) -> None:
+    with pytest.raises(ValueError, match="max_tokens"):
+        anthropic_module.from_args({"model": "claude-sonnet-4-5", "max_tokens": bad})
+
+
+def test_anthropic_model_exported_from_models_package() -> None:
+    assert issubclass(AnthropicModel, anthropic_module.BaseModel)
+    assert "AnthropicModel" in models_pkg.__all__
+
+
+def test_predict_is_traced_once_as_rai_model_predict() -> None:
+    assert AnthropicModel.predict.__rai_traced_op_name__ == "rai.model.predict"  # type: ignore[attr-defined]
+
+
+def test_package_imports_work_without_anthropic_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "anthropic", None)
+
+    importlib.invalidate_caches()
+    reloaded = importlib.reload(anthropic_module)
+    assert issubclass(reloaded.AnthropicModel, reloaded.BaseModel)
+
+
+async def test_predict_raises_helpful_error_without_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "anthropic", None)
+
+    model = AnthropicModel(model="claude-sonnet-4-5")
+
+    with pytest.raises(ImportError, match="anthropic"):
+        await model.predict("Review this answer.")


### PR DESCRIPTION
## Related issue

Closes #55 

## What changed

Adds an optional `AnthropicModel` backed by Anthropic's async Messages API
client, exposed from `rai_toolkit.models` with a `from_args()` helper. The
anthropic SDK is imported lazily behind the new `[anthropic]` extra so the
core package keeps working without it.

System prompt and retrieved context go through the top-level `system`
parameter, output aggregates all text blocks, and response metadata is
normalized to the existing `ModelResponse` keys. Covered by fully mocked
offline tests for client configuration, API key handling, `max_tokens`
defaults and overrides, text extraction, metadata, and `from_args()`.

Behaviour / compatibility notes:

- `max_tokens` defaults to `1024`, is overridable per call, and rejects
  non-positive values.
- No env-var fallback key: resolution is left to the Anthropic SDK.
- Files touched: `rai_toolkit/models/anthropic.py` (new),
  `tests/test_anthropic.py` (new, 20 tests), `rai_toolkit/models/__init__.py`,
  `pyproject.toml`, `README.md`.

## Validation

- `pytest -q` (Python 3.10/3.11/3.12, `.[dev,anthropic]`): 89 passed, 4 skipped
- `pytest -q` (Python 3.12, `.[dev]` only): 69 passed, 5 skipped
- `pytest -q` (Python 3.12, `.[dev,weave]` + weave 0.52.40): 75 passed, 1 skipped
- `ruff check --select E9,F63,F7,F82 .`: clean
- `reuse --no-multiprocessing lint`: 115/115 compliant
- `python -m build`: wheel + sdist build; wheel installs in a clean venv,
  `pip check` clean, import works without the anthropic extra

## AI assistance

Implementation was AI-assisted (per CONTRIBUTING.md). SDK usage and local
validation were verified by the author; I can explain any line on request.

## Checklist

- [x] I checked the issue's Development section and open pull requests for
      linked work.
- [x] This pull request is focused on one change.
- [x] Behavioural changes include tests, or I explained why a test is not
      needed.
- [x] I included the local validation commands and results.
- [x] I updated documentation for user-visible changes.
- [x] I checked ownership before adding or changing SPDX headers.
