### PR TITLE
docs: update PR template copyright owner

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 Karan Nisar
+SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
 SPDX-License-Identifier: Apache-2.0
 SPDX-PackageName: rai-toolkit
 -->


### PR DESCRIPTION
## What changed

Updated the SPDX copyright owner in the pull request template from `Karan Nisar` to `CoreWeave, Inc.`. No contributor-facing template text changed.

## Validation

- Reviewed the GitHub diff: one file changed, with one line replaced.
- Confirmed the license and package fields are unchanged.

## Checklist

- [x] This pull request is focused on one change.
- [x] This is a documentation-only change, so no tests are needed.
- [x] I checked ownership before changing the SPDX header.
