### PR TITLE
feat: add context precision and recall scorers for RAG retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,12 @@ present and retains verified supporting or contradicting spans as evidence.
 The `RetrievalRelevanceScorer` grades retrieval quality itself: it validates
 the judge's per-chunk relevance verdicts against the parsed chunks, derives
 the overall score from them, and returns un-assessed rather than silently
-passing when the judge reply cannot be trusted.
+passing when the judge reply cannot be trusted. The `ContextPrecisionScorer`
+and `ContextRecallScorer` measure the retrieved set as a whole rather than
+chunk by chunk: precision reports the fraction of retrieved chunks the query
+actually needed, and recall reports how much of the row's reference answer the
+retrieval supplied. Both derive their score from validated verdicts, so a
+judge that cannot be trusted leaves the row un-assessed instead of scoring it.
 
 ## Weave-native evaluation in assessment
 

--- a/rai_toolkit/prompts/judge_prompts.py
+++ b/rai_toolkit/prompts/judge_prompts.py
@@ -142,7 +142,9 @@ CONTEXT_PRECISION_SCORER_SYSTEM = (
     "a whole: a chunk that repeats information another retrieved chunk already "
     "supplies is not needed, even though it is on topic. Precision measures how "
     "much of the retrieved set was necessary, so redundant or off-topic chunks "
-    "count against it."
+    "count against it. When two chunks contain the same information, exactly one "
+    "of them is needed: the one with the lowest chunk index. Every later chunk "
+    "repeating that information is not needed."
 )
 
 CONTEXT_PRECISION_SCORER_TEMPLATE = """Decide whether each retrieved context chunk was needed to answer the user query.
@@ -158,7 +160,11 @@ Assign each chunk a label:
 
 Judge the retrieved set as a whole. A chunk that is on topic but repeats another
 chunk's information is "not_needed": precision asks how much of the retrieved set
-was necessary, not how much of it was on topic.
+was necessary, not how much of it was on topic. Apply one fixed rule when chunks
+repeat each other: if two chunks contain the same information, the chunk with the
+lowest chunk_index is the one that supplies it and is "needed"; every later chunk
+repeating that information is "not_needed", even when the chunks are otherwise
+identical.
 
 Score overall precision on a 0-3 scale:
 - 3: Every retrieved chunk was needed.
@@ -181,7 +187,9 @@ CONTEXT_RECALL_SCORER_SYSTEM = (
     "break a reference answer into the individual pieces of information it "
     "contains, then decide whether the retrieved context supplies each piece. "
     "Work only from the reference answer: every piece you list must be copied "
-    "verbatim from it, never paraphrased and never invented. A piece counts as "
+    "verbatim from it, never paraphrased and never invented. Decompose the "
+    "reference completely: the pieces must together cover the whole reference "
+    "answer, omit no part of it, and not overlap each other. A piece counts as "
     "supplied only when the retrieved context states it; topically related or "
     "partially matching content does not count."
 )
@@ -197,15 +205,21 @@ CONTEXT_RECALL_SCORER_TEMPLATE = """Decide how much of the reference answer the 
 Break the Reference Answer into its individual pieces of information: separate
 facts, figures, conditions, and recommendations. List each piece with an exact
 verbatim span copied from the Reference Answer. Do not paraphrase and do not add
-pieces the Reference Answer does not state.
+pieces the Reference Answer does not state. The pieces must together form a
+complete decomposition of the Reference Answer: every part of it belongs to
+exactly one piece, no part may be omitted, and no two pieces may overlap.
 
-For each piece, decide whether the Retrieved Context supplies it:
-- "supported": the retrieved context states this piece of information.
-- "not_supported": the retrieved context does not state it, or states only a
-  related but different fact.
+For each piece, decide whether the Retrieved Context supplies it, and record the
+verdict as a JSON Boolean in the "supported" field:
+- true: the retrieved context states this piece of information.
+- false: the retrieved context does not state it, or states only a related but
+  different fact.
+Use only the Boolean values true and false; never a quoted string label.
 
 For each supported piece, give an exact verbatim span copied from the Retrieved
-Context that states it. Spans must be copied exactly; do not paraphrase.
+Context that states it. Spans must be copied exactly; do not paraphrase. Quote
+the chunk's text itself, never the <chunk ...> envelope marker or the chunk's
+[source-id] label.
 
 Score overall recall on a 0-3 scale:
 - 3: Every piece of information in the reference answer is supplied by the retrieved context.

--- a/rai_toolkit/prompts/judge_prompts.py
+++ b/rai_toolkit/prompts/judge_prompts.py
@@ -134,6 +134,95 @@ Respond in JSON format:
   ]
 }}"""
 
+CONTEXT_PRECISION_SCORER_SYSTEM = (
+    "You are a strict retrieval-precision auditor for RAG systems. Your job is to "
+    "decide, for each retrieved context chunk, whether that chunk was actually "
+    "needed to answer the user query. A chunk is needed only if it supplies "
+    "information the query asks for. Judge each chunk against the retrieved set as "
+    "a whole: a chunk that repeats information another retrieved chunk already "
+    "supplies is not needed, even though it is on topic. Precision measures how "
+    "much of the retrieved set was necessary, so redundant or off-topic chunks "
+    "count against it."
+)
+
+CONTEXT_PRECISION_SCORER_TEMPLATE = """Decide whether each retrieved context chunk was needed to answer the user query.
+
+**User Query:** {input}
+
+**Retrieved Context (each retrieved chunk is wrapped in a numbered <chunk index="N">...</chunk> envelope):** {context}
+
+Return a per-chunk verdict. Each chunk is exactly one numbered <chunk index="N"> envelope above; use the envelope's index as the chunk_index.
+Assign each chunk a label:
+- "needed": the chunk supplies information the query asks for that no other retrieved chunk supplies.
+- "not_needed": the chunk is off-topic, or the information it supplies is already covered by another retrieved chunk.
+
+Judge the retrieved set as a whole. A chunk that is on topic but repeats another
+chunk's information is "not_needed": precision asks how much of the retrieved set
+was necessary, not how much of it was on topic.
+
+Score overall precision on a 0-3 scale:
+- 3: Every retrieved chunk was needed.
+- 2: Most chunks were needed, but at least one was redundant or off-topic.
+- 1: At most half of the chunks were needed.
+- 0: No chunk was needed.
+
+Respond in JSON format:
+{{
+  "score": <0-3>,
+  "explanation": "<brief reasoning about how much of the retrieved set was needed>",
+  "chunk_verdicts": [
+    {{"chunk_index": 0, "needed": "needed|not_needed", "reason": "<one short sentence>"}},
+    ...
+  ]
+}}"""
+
+CONTEXT_RECALL_SCORER_SYSTEM = (
+    "You are a strict retrieval-recall auditor for RAG systems. Your job is to "
+    "break a reference answer into the individual pieces of information it "
+    "contains, then decide whether the retrieved context supplies each piece. "
+    "Work only from the reference answer: every piece you list must be copied "
+    "verbatim from it, never paraphrased and never invented. A piece counts as "
+    "supplied only when the retrieved context states it; topically related or "
+    "partially matching content does not count."
+)
+
+CONTEXT_RECALL_SCORER_TEMPLATE = """Decide how much of the reference answer the retrieved context supplies.
+
+**User Query:** {input}
+
+**Retrieved Context (each retrieved chunk is wrapped in a numbered <chunk index="N">...</chunk> envelope):** {context}
+
+**Reference Answer:** {expected}
+
+Break the Reference Answer into its individual pieces of information: separate
+facts, figures, conditions, and recommendations. List each piece with an exact
+verbatim span copied from the Reference Answer. Do not paraphrase and do not add
+pieces the Reference Answer does not state.
+
+For each piece, decide whether the Retrieved Context supplies it:
+- "supported": the retrieved context states this piece of information.
+- "not_supported": the retrieved context does not state it, or states only a
+  related but different fact.
+
+For each supported piece, give an exact verbatim span copied from the Retrieved
+Context that states it. Spans must be copied exactly; do not paraphrase.
+
+Score overall recall on a 0-3 scale:
+- 3: Every piece of information in the reference answer is supplied by the retrieved context.
+- 2: Most pieces are supplied, but at least one is missing.
+- 1: At most half of the pieces are supplied.
+- 0: None of the pieces are supplied.
+
+Respond in JSON format:
+{{
+  "score": <0-3>,
+  "explanation": "<brief reasoning about what was and was not retrieved>",
+  "reference_items": [
+    {{"reference_span": "<exact text copied from the Reference Answer>", "supported": true, "context_span": "<exact text copied from the Retrieved Context>", "reason": "<one short sentence>"}},
+    ...
+  ]
+}}"""
+
 FAIRNESS_JUDGE_SYSTEM = (
     "You are an expert in AI fairness and bias detection. Your job is to evaluate "
     "AI-generated responses for unfair bias, discrimination, or stereotyping related "
@@ -374,5 +463,13 @@ JUDGE_PROMPTS: dict[str, dict[str, str]] = {
     "RetrievalRelevanceScorer": {
         "system": RETRIEVAL_RELEVANCE_SCORER_SYSTEM,
         "template": RETRIEVAL_RELEVANCE_SCORER_TEMPLATE,
+    },
+    "ContextPrecisionScorer": {
+        "system": CONTEXT_PRECISION_SCORER_SYSTEM,
+        "template": CONTEXT_PRECISION_SCORER_TEMPLATE,
+    },
+    "ContextRecallScorer": {
+        "system": CONTEXT_RECALL_SCORER_SYSTEM,
+        "template": CONTEXT_RECALL_SCORER_TEMPLATE,
     },
 }

--- a/rai_toolkit/scorers/__init__.py
+++ b/rai_toolkit/scorers/__init__.py
@@ -8,6 +8,8 @@ from rai_toolkit.scorers.base import BaseScorer, ScorerResult
 from rai_toolkit.scorers.composite import CompositeScorer
 from rai_toolkit.scorers.llm_judges import (
     ContentSafetyJudge,
+    ContextPrecisionScorer,
+    ContextRecallScorer,
     ExplainabilityJudge,
     FactualityJudge,
     FairnessJudge,
@@ -31,6 +33,8 @@ __all__ = [
     "BaseScorer",
     "CompositeScorer",
     "ContentSafetyJudge",
+    "ContextPrecisionScorer",
+    "ContextRecallScorer",
     "ExplainabilityJudge",
     "FactualityJudge",
     "FairnessJudge",

--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -532,34 +532,41 @@ def _xml_unescape_prompt_text(text: str) -> str:
     return text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
 
 
-_ENVELOPE_OR_LABEL_PATTERN = re.compile(r"\[[^\[\]]*\]|</?chunk\b[^>]*>")
+_ENVELOPE_MARKER_PATTERN = re.compile(r"</?chunk\b[^>]*>")
 
 
-def _is_envelope_or_label_only(span: str) -> bool:
+def _is_envelope_or_label_only(span: str, chunk: str) -> bool:
     """Return True when a quoted span carries no chunk content, only syntax.
 
-    A ``<chunk index="N">`` envelope marker or a ``[source-id]`` label is part
-    of the prompt scaffolding (or, for a label, the chunk's first token), not
-    evidence that the retrieval supplied a piece of information. A span made
-    up solely of such markers -- or of whitespace around them -- verifies
-    nothing, even when the text is genuinely present in a chunk.
+    A ``<chunk index="N">`` envelope marker is prompt scaffolding, and the
+    matched chunk's own leading ``[source-id]`` label names the source rather
+    than stating anything, so a span made up solely of such markers -- or of
+    whitespace around them -- verifies nothing. Bracketed text that is not
+    that label (``[FDA]`` in the chunk body) is chunk content and survives
+    this check.
     """
-    return not _ENVELOPE_OR_LABEL_PATTERN.sub("", span).strip()
+    residue = _ENVELOPE_MARKER_PATTERN.sub("", span)
+    label_match = _SOURCE_LABEL_PATTERN.match(chunk)
+    if label_match:
+        residue = residue.replace(label_match.group(0), "")
+    return not residue.strip()
 
 
-def _context_span_in_chunks(span: str, chunks: list[str]) -> str:
+def _context_span_in_chunks(span: str, chunks: list[str]) -> tuple[str, str]:
     """Verify a quoted span against the original chunk content, not the prompt.
 
-    Returns the span verbatim as it appears in the matching original chunk, or
-    "" when no chunk contains it. Matching against a single original chunk
-    (rather than the rendered envelope sequence) keeps evidence anchored to
-    what was actually retrieved and cannot be satisfied by envelope syntax.
+    Returns ``(verified_span, matched_chunk)`` -- the span verbatim as it
+    appears in the matching original chunk, and that chunk so the caller can
+    tell scaffolding from the chunk's own label -- or ``("", "")`` when no
+    chunk contains it. Matching against a single original chunk (rather than
+    the rendered envelope sequence) keeps evidence anchored to what was
+    actually retrieved and cannot be satisfied by envelope syntax.
     """
     for chunk in chunks:
         verified = _verbatim_span(span, chunk)
         if verified:
-            return verified
-    return ""
+            return verified, chunk
+    return "", ""
 
 
 def _normalized_occurrences(span: str, normalized_row: str) -> list[tuple[int, int]]:
@@ -580,34 +587,37 @@ def _normalized_occurrences(span: str, normalized_row: str) -> list[tuple[int, i
 
 
 def _check_reference_decomposition(
-    reference_spans: list[str], expected: str
+    bound_pieces: list[tuple[str, int, int]], expected: str
 ) -> tuple[list[str], list[str]]:
-    """Check that verbatim reference spans tile the whole reference answer.
+    """Check that bound reference pieces tile the whole reference answer.
+
+    Each piece arrives as ``(span, start, end)`` with its interval already
+    bound to one occurrence of the span in the normalized reference text (see
+    the recall scorer), so this function never re-derives occurrences: one
+    item covers exactly the occurrence it was bound to, never every repeated
+    occurrence at once.
 
     Returns ``(overlapping_spans, uncovered_texts)``; both empty means the
-    spans form a complete, non-overlapping decomposition: every piece of the
-    reference is listed by exactly one item. Whitespace between pieces does
-    not break completeness. Anything else is a judge that trimmed the
+    pieces form a complete, non-overlapping decomposition: every part of the
+    reference is covered by exactly one bound piece. Whitespace between pieces
+    does not break completeness. Anything else is a judge that trimmed the
     denominator (omitted pieces) or listed the same text twice under
     overlapping spans -- either way the recall score would be inflated, so
     the caller fails the parse.
     """
     normalized_expected, offsets = _normalized_text_with_offsets(expected)
-    intervals: list[tuple[int, int, str]] = []
-    for span in reference_spans:
-        for start, end in _normalized_occurrences(span, normalized_expected):
-            intervals.append((start, end, span))
+    intervals: list[tuple[int, int, str]] = [
+        (start, end, span) for span, start, end in bound_pieces
+    ]
     intervals.sort()
 
     overlapping: set[str] = set()
     active_end = -1
     active_span = ""
     for start, end, span in intervals:
-        # Same-span intervals are repeated occurrences of one item's piece,
-        # not ambiguity; distinct spans that intersect are (both intervals
-        # are sorted by start, so an active interval that reaches past the
-        # current start genuinely overlaps it).
-        if active_span and start < active_end and span != active_span:
+        # Intervals are sorted by start, so an active interval that reaches
+        # past the current start genuinely overlaps it.
+        if active_span and start < active_end:
             overlapping.add(active_span)
             overlapping.add(span)
         if end > active_end:
@@ -971,7 +981,11 @@ class ContextPrecisionScorer(LLMJudgeScorer):
     would otherwise apply symmetrically to both copies. The prompt fixes the
     tie-break deterministically: the lowest-index chunk supplying the
     information is the needed one, and every later chunk repeating it is not
-    needed, so identical chunks cannot both be marked needed.
+    needed, so identical chunks cannot both be marked needed. Exact
+    duplicates are mechanically decidable, so the scorer enforces that rule
+    itself: a later exact duplicate of an earlier chunk is demoted to
+    ``not_needed`` even when the judge marked it needed, and every demotion
+    is recorded in ``details["duplicate_chunk_corrections"]``.
 
     Verdicts that are not dicts, carry a non-integer ``chunk_index``, or an
     unrecognized label are discarded and reported in
@@ -1148,14 +1162,45 @@ class ContextPrecisionScorer(LLMJudgeScorer):
                 assessed=False,
             )
 
-        needed_count = sum(
-            1 for v in valid_verdicts.values() if v.get("needed") == "needed"
-        )
+        # Exact duplicates are mechanically decidable, so the prompt's
+        # lowest-index rule is enforced here rather than trusted to the judge:
+        # within a group of chunks with identical content only the lowest
+        # index can be needed, and a later copy marked needed is demoted and
+        # recorded. Without this, a judge marking both copies of a duplicated
+        # chunk needed would score perfect precision. Chunks are grouped by
+        # whitespace-collapsed content, so delimiter padding around a ``---``
+        # fallback chunk does not hide the duplication.
+        content_groups: dict[str, list[int]] = {}
+        for index in range(len(chunks)):
+            normalized_chunk = _normalized_text_with_offsets(chunks[index])[0].strip()
+            content_groups.setdefault(normalized_chunk, []).append(index)
+        needed_by_index: dict[int, str] = {
+            index: str(valid_verdicts[index].get("needed"))
+            for index in valid_verdicts
+        }
+        duplicate_chunk_corrections: list[dict[str, Any]] = []
+        for indexes in content_groups.values():
+            for index in indexes[1:]:
+                if needed_by_index[index] == "needed":
+                    needed_by_index[index] = "not_needed"
+                    duplicate_chunk_corrections.append(
+                        {
+                            "chunk_index": index,
+                            "duplicate_of": indexes[0],
+                            "reason": (
+                                "Exact duplicate of chunk "
+                                f"{indexes[0]}; the lowest-index chunk "
+                                "supplies the information."
+                            ),
+                        }
+                    )
+
+        needed_count = sum(1 for label in needed_by_index.values() if label == "needed")
         precision = needed_count / len(chunks)
         chunk_verdicts = [
             {
                 "chunk_index": index,
-                "needed": valid_verdicts[index].get("needed"),
+                "needed": needed_by_index[index],
                 "reason": str(valid_verdicts[index].get("reason", "")),
             }
             for index in sorted(valid_verdicts)
@@ -1178,6 +1223,7 @@ class ContextPrecisionScorer(LLMJudgeScorer):
                 "chunk_verdicts": chunk_verdicts,
                 "needed_chunks": needed_count,
                 "total_chunks": len(chunks),
+                "duplicate_chunk_corrections": duplicate_chunk_corrections,
                 "discarded_verdicts": discarded_verdicts,
                 "judge_score": judge_score,
                 "judge_explanation": str(result.get("explanation", "")),
@@ -1210,18 +1256,26 @@ class ContextRecallScorer(LLMJudgeScorer):
       envelope marker or the chunk's source label is not evidence, and a
       support claim that cannot be verified this way is counted as not
       supported rather than trusted.
-    - A duplicated reference span fails the parse: the same information listed
-      twice would otherwise double-count in the denominator.
+    - Each piece is bound to exactly one occurrence of its reference span: the
+      earliest occurrence no earlier piece has claimed. A span the reference
+      repeats must be listed once per occurrence -- one piece can never cover
+      every repeated occurrence -- and a listing with no unclaimed occurrence
+      left fails the parse, since the same information listed twice would
+      double-count in the denominator.
     - The surviving pieces must form a complete, non-overlapping decomposition
       of the reference: overlapping spans, or reference text no piece covers,
       fail the parse. A judge could otherwise shrink the denominator by
       omitting the pieces the retrieval missed -- a two-fact reference where
       only the supported fact is listed would score a perfect recall.
 
-    The score is ``supported / valid pieces``, derived from the validated items.
-    The judge's own overall score is advisory and recorded in
-    ``details["judge_score"]``. A reply that yields no valid piece is a parse
-    failure rather than a perfect or empty score.
+    The score is ``supported regions / regions``, derived from the validated
+    pieces: adjacent pieces sharing a verdict are merged into maximal stretches
+    of the reference first, so the score depends on which parts of the
+    reference are supplied, not on how the judge happened to partition it --
+    two replies that make the same supported / not-supported claim over the
+    reference score identically. The judge's own overall score is advisory and
+    recorded in ``details["judge_score"]``. A reply that yields no valid piece
+    is a parse failure rather than a perfect or empty score.
 
     Rows without retrieved context, with a blank query, or without a reference
     answer return ``assessed=False`` (``skipped`` is ``empty_context`` /
@@ -1336,10 +1390,12 @@ class ContextRecallScorer(LLMJudgeScorer):
         judge_score = _advisory_judge_score(result.get("score"))
 
         valid_items: list[dict[str, Any]] = []
-        seen_spans: set[str] = set()
+        item_intervals: list[tuple[int, int]] = []
+        bound_occurrences: set[tuple[int, int]] = set()
         duplicate_spans: list[str] = []
         discarded_items = 0
         unverified_support_items = 0
+        normalized_expected, _expected_offsets = _normalized_text_with_offsets(expected)
         raw_items = result.get("reference_items")
         if isinstance(raw_items, list):
             for item in raw_items:
@@ -1354,11 +1410,26 @@ class ContextRecallScorer(LLMJudgeScorer):
                 if not reference_span:
                     discarded_items += 1
                     continue
-                if reference_span in seen_spans:
+                # Each item is bound to exactly one occurrence of its span in
+                # the reference: the earliest occurrence no earlier item has
+                # claimed. A span the reference repeats must be listed once
+                # per occurrence -- one item can never cover every repeated
+                # occurrence, and a listing with no unclaimed occurrence left
+                # is a duplicate.
+                interval = next(
+                    (
+                        occurrence
+                        for occurrence in _normalized_occurrences(
+                            reference_span, normalized_expected
+                        )
+                        if occurrence not in bound_occurrences
+                    ),
+                    None,
+                )
+                if interval is None:
                     duplicate_spans.append(reference_span)
                     discarded_items += 1
                     continue
-                seen_spans.add(reference_span)
                 supported = item.get("supported")
                 if not isinstance(supported, bool):
                     discarded_items += 1
@@ -1374,8 +1445,12 @@ class ContextRecallScorer(LLMJudgeScorer):
                         # would verify as false evidence. The stored span is
                         # the original chunk text, not the escaped quote.
                         unescaped_span = _xml_unescape_prompt_text(raw_context_span)
-                        context_span = _context_span_in_chunks(unescaped_span, chunks)
-                        if context_span and _is_envelope_or_label_only(context_span):
+                        context_span, matched_chunk = _context_span_in_chunks(
+                            unescaped_span, chunks
+                        )
+                        if context_span and _is_envelope_or_label_only(
+                            context_span, matched_chunk
+                        ):
                             context_span = ""
                     if not context_span:
                         # The judge claims support but cannot show it in the
@@ -1390,6 +1465,8 @@ class ContextRecallScorer(LLMJudgeScorer):
                         "reason": str(item.get("reason", "")),
                     }
                 )
+                item_intervals.append(interval)
+                bound_occurrences.add(interval)
 
         if duplicate_spans:
             return ScorerResult(
@@ -1397,10 +1474,11 @@ class ContextRecallScorer(LLMJudgeScorer):
                 passed=False,
                 category=self.category,
                 explanation=(
-                    "Un-assessed: the judge listed the same reference span more "
-                    "than once, which would double-count that piece of "
-                    "information in the recall denominator. Inspect "
-                    "details.judge_response to see what the judge returned."
+                    "Un-assessed: the judge listed a reference span more times "
+                    "than the reference contains it, which would double-count "
+                    "that piece of information in the recall denominator. "
+                    "Inspect details.judge_response to see what the judge "
+                    "returned."
                 ),
                 details={
                     "skipped": "judge_parse_failure",
@@ -1444,7 +1522,11 @@ class ContextRecallScorer(LLMJudgeScorer):
         # count the same reference text as separate pieces. Either way the
         # denominator is not trustworthy, so the row is un-assessed.
         overlapping_spans, uncovered_texts = _check_reference_decomposition(
-            [item["reference_span"] for item in valid_items], expected
+            [
+                (item["reference_span"], start, end)
+                for item, (start, end) in zip(valid_items, item_intervals)
+            ],
+            expected,
         )
         if overlapping_spans:
             return ScorerResult(
@@ -1492,10 +1574,30 @@ class ContextRecallScorer(LLMJudgeScorer):
                 assessed=False,
             )
 
-        supported_count = sum(1 for item in valid_items if item["supported"])
-        recall = supported_count / len(valid_items)
+        # Adjacent pieces sharing a verdict are merged into maximal stretches
+        # of the reference before scoring: the score depends on which parts of
+        # the reference are supplied, not on how the judge happened to
+        # partition it. Two replies that make the same supported /
+        # not-supported claim over the reference -- one listing a whole
+        # sentence, the other splitting it into words -- score identically,
+        # because the decomposition check has already pinned every gap between
+        # bound pieces to whitespace.
+        ordered: list[tuple[tuple[int, int], bool]] = sorted(
+            zip(item_intervals, (bool(item["supported"]) for item in valid_items))
+        )
+        total_regions = 0
+        supported_regions = 0
+        previous_supported: bool | None = None
+        for _interval, supported_flag in ordered:
+            if supported_flag != previous_supported:
+                total_regions += 1
+                if supported_flag:
+                    supported_regions += 1
+            previous_supported = supported_flag
+
+        recall = supported_regions / total_regions
         explanation = (
-            f"{supported_count} of {len(valid_items)} reference piece(s) "
+            f"{supported_regions} of {total_regions} reference region(s) "
             f"supplied; recall {recall:.2f}, threshold {self.threshold}."
         )
 
@@ -1510,8 +1612,8 @@ class ContextRecallScorer(LLMJudgeScorer):
                 "max_score": 1,
                 "judge_model": self.model,
                 "reference_items": valid_items,
-                "supported_items": supported_count,
-                "total_items": len(valid_items),
+                "supported_regions": supported_regions,
+                "total_regions": total_regions,
                 "unverified_support_items": unverified_support_items,
                 "discarded_items": discarded_items,
                 "judge_score": judge_score,

--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -824,6 +824,515 @@ class RetrievalRelevanceScorer(LLMJudgeScorer):
         )
 
 
+def _advisory_judge_score(raw_score: Any) -> float | None:
+    """Parse the judge's own overall score as an advisory audit value.
+
+    The scorers below always derive their score from validated verdicts; the
+    judge's own number is recorded in ``details["judge_score"]`` only. A bool is
+    rejected rather than coerced (``float(True)`` is 1.0 and a boolean is not a
+    score), and an unparseable or non-finite value becomes ``None``.
+    """
+    if isinstance(raw_score, bool):
+        return None
+    try:
+        score = float(raw_score)
+    except (TypeError, ValueError):
+        return None
+    return score if math.isfinite(score) else None
+
+
+class ContextPrecisionScorer(LLMJudgeScorer):
+    """Measure the fraction of retrieved chunks the query actually needed.
+
+    Precision is a set-level measurement, not a per-chunk grade: it answers "of
+    the chunks that were retrieved, how many were actually needed to answer the
+    query", so a retriever that pads the context window with redundant or
+    off-topic chunks scores low even when every chunk is individually on topic.
+    That is the difference from ``RetrievalRelevanceScorer``, which grades each
+    chunk on its own and therefore cannot see redundancy across chunks.
+
+    Chunks follow the toolkit's context contract (see
+    ``_split_context_chunks``) and the judge reads them re-rendered into
+    numbered ``<chunk index="N">`` envelopes. The judge returns a binary
+    ``needed`` / ``not_needed`` verdict per chunk, and the scorer derives the
+    score as ``needed / total`` from the validated verdicts. The judge's own
+    overall score is advisory and recorded in ``details["judge_score"]``.
+
+    Verdicts that are not dicts, carry a non-integer ``chunk_index``, or an
+    unrecognized label are discarded and reported in
+    ``details["discarded_verdicts"]``. A duplicated or out-of-range
+    ``chunk_index``, or a real chunk with no verdict, fails the parse (the
+    per-chunk grading would be ambiguous) and the row is returned un-assessed
+    with ``skipped="judge_parse_failure"``.
+
+    Rows without retrieved context or with a blank query return
+    ``assessed=False``. Refusal-shaped rows are still assessed: this scorer
+    grades the retriever, and retrieved context remains gradable even when the
+    generator declines to answer.
+    """
+
+    name = "ContextPrecisionScorer"
+    description = (
+        "Measures the fraction of retrieved context chunks the query actually needed"
+    )
+    category = "MIT-3.1"
+    _judge_name = "ContextPrecisionScorer"
+
+    def score(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: Any,
+    ) -> ScorerResult:
+        # Chunk count comes from the context, never from the judge's verdict
+        # list: the scorer and the judge must agree on what was retrieved.
+        chunks = _split_context_chunks(context)
+        if not chunks:
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: no retrieved context is available. "
+                    "ContextPrecisionScorer measures how much of the retrieved "
+                    "set was needed; without context there is nothing to assess."
+                ),
+                details={
+                    "skipped": "empty_context",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                },
+                assessed=False,
+            )
+        if not (input or "").strip():
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: no user query available. Context precision "
+                    "asks whether chunks were needed to answer the query; with "
+                    "a blank query there is nothing for a chunk to be needed for."
+                ),
+                details={
+                    "skipped": "empty_query",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                },
+                assessed=False,
+            )
+
+        prompts = self._get_prompts()
+        # Rebuild the prompt from the exact parsed chunk sequence so the judge's
+        # indexes line up with the chunks the scorer counts.
+        parsed_context = _render_context_chunks(chunks)
+        user_prompt = self._format_prompt(
+            output=output, input=input, context=parsed_context
+        )
+        result = self._call_judge(prompts["system"], user_prompt)
+        if not isinstance(result, dict):
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge reply was valid JSON but not an "
+                    "object, so it carries no per-chunk verdicts. Inspect "
+                    "details.judge_response to see what the judge returned."
+                ),
+                details={
+                    "skipped": "judge_parse_failure",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                    "judge_response": _sanitize_judge_value(result),
+                    "total_chunks": len(chunks),
+                },
+                assessed=False,
+            )
+
+        judge_score = _advisory_judge_score(result.get("score"))
+
+        recognized_labels = ("needed", "not_needed")
+        valid_verdicts: dict[int, dict[str, Any]] = {}
+        seen_indexes: set[int] = set()
+        duplicate_indexes: list[int] = []
+        out_of_range_indexes: list[int] = []
+        discarded_verdicts = 0
+        raw_verdicts = result.get("chunk_verdicts")
+        if isinstance(raw_verdicts, list):
+            for verdict in raw_verdicts:
+                if not isinstance(verdict, dict):
+                    discarded_verdicts += 1
+                    continue
+                raw_index = verdict.get("chunk_index")
+                if isinstance(raw_index, bool) or not isinstance(raw_index, int):
+                    discarded_verdicts += 1
+                    continue
+                index = raw_index
+                if not 0 <= index < len(chunks):
+                    out_of_range_indexes.append(index)
+                    continue
+                if index in seen_indexes:
+                    duplicate_indexes.append(index)
+                    discarded_verdicts += 1
+                    continue
+                seen_indexes.add(index)
+                if verdict.get("needed") not in recognized_labels:
+                    discarded_verdicts += 1
+                    continue
+                valid_verdicts[index] = verdict
+
+        if duplicate_indexes or out_of_range_indexes:
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge returned a verdict for a chunk "
+                    "outside the parsed range or more than one verdict for the "
+                    "same chunk. Either makes the per-chunk grading ambiguous; "
+                    "inspect details.judge_response to see what the judge "
+                    "returned."
+                ),
+                details={
+                    "skipped": "judge_parse_failure",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                    "judge_response": _sanitize_judge_value(result),
+                    "total_chunks": len(chunks),
+                    "covered_chunks": len(valid_verdicts),
+                    "duplicate_chunk_indexes": sorted(set(duplicate_indexes)),
+                    "out_of_range_chunk_indexes": sorted(set(out_of_range_indexes)),
+                    "discarded_verdicts": discarded_verdicts,
+                },
+                assessed=False,
+            )
+
+        missing_indexes = sorted(set(range(len(chunks))) - set(valid_verdicts))
+        if missing_indexes:
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge did not return a parseable verdict "
+                    "for every chunk. Inspect details.judge_response to see "
+                    "what the judge returned."
+                ),
+                details={
+                    "skipped": "judge_parse_failure",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                    "judge_response": _sanitize_judge_value(result),
+                    "total_chunks": len(chunks),
+                    "covered_chunks": len(valid_verdicts),
+                    "missing_chunk_indexes": missing_indexes,
+                    "discarded_verdicts": discarded_verdicts,
+                },
+                assessed=False,
+            )
+
+        needed_count = sum(
+            1 for v in valid_verdicts.values() if v.get("needed") == "needed"
+        )
+        precision = needed_count / len(chunks)
+        chunk_verdicts = [
+            {
+                "chunk_index": index,
+                "needed": valid_verdicts[index].get("needed"),
+                "reason": str(valid_verdicts[index].get("reason", "")),
+            }
+            for index in sorted(valid_verdicts)
+        ]
+        explanation = (
+            f"{needed_count} of {len(chunks)} retrieved chunk(s) needed; "
+            f"precision {precision:.2f}, threshold {self.threshold}."
+        )
+
+        return ScorerResult(
+            score=precision,
+            passed=ScoreNormalizer.apply_threshold(precision, self.threshold),
+            category=self.category,
+            explanation=explanation,
+            details={
+                "scorer_name": self.name,
+                "raw_score": precision,
+                "max_score": 1,
+                "judge_model": self.model,
+                "chunk_verdicts": chunk_verdicts,
+                "needed_chunks": needed_count,
+                "total_chunks": len(chunks),
+                "discarded_verdicts": discarded_verdicts,
+                "judge_score": judge_score,
+                "judge_explanation": str(result.get("explanation", "")),
+            },
+        )
+
+
+class ContextRecallScorer(LLMJudgeScorer):
+    """Measure how much of the reference answer the retrieved context supplied.
+
+    Recall is a set-level measurement: it answers "of the information needed to
+    answer the query, how much did the retrieval actually supply", so a
+    retriever that misses the one chunk that mattered scores low even when every
+    chunk it did return is relevant. That is the difference from
+    ``RetrievalRelevanceScorer``, which can only grade what was retrieved and is
+    blind to a chunk that was never returned at all.
+
+    The judge decomposes the row's reference answer (``expected``) into
+    individual pieces of information, each anchored to a verbatim span of the
+    reference, and marks each piece ``supported`` or ``not_supported`` with a
+    verbatim context span as evidence. The scorer validates those anchors:
+
+    - A piece whose reference span is not verbatim in ``expected`` is discarded,
+      so a judge cannot invent information the reference does not contain.
+    - A piece whose ``supported`` flag is not a boolean is discarded.
+    - A ``supported`` piece whose context span is not verbatim in the rendered
+      chunk sequence the judge read is counted as not supported, because the
+      support claim cannot be verified.
+    - A duplicated reference span fails the parse: the same information listed
+      twice would otherwise double-count in the denominator.
+
+    The score is ``supported / valid pieces``, derived from the validated items.
+    The judge's own overall score is advisory and recorded in
+    ``details["judge_score"]``. A reply that yields no valid piece is a parse
+    failure rather than a perfect or empty score.
+
+    Rows without retrieved context, with a blank query, or without a reference
+    answer return ``assessed=False`` (``skipped`` is ``empty_context`` /
+    ``empty_query`` / ``missing_reference``): recall needs a reference to
+    measure against, and an absent one is a coverage gap, not a zero. Refusal-
+    shaped rows are still assessed: this scorer grades the retriever.
+    """
+
+    name = "ContextRecallScorer"
+    description = (
+        "Measures how much of the reference answer the retrieved context supplied"
+    )
+    category = "MIT-3.1"
+    _judge_name = "ContextRecallScorer"
+
+    def score(
+        self,
+        output: str,
+        input: str = "",
+        context: str = "",
+        **kwargs: Any,
+    ) -> ScorerResult:
+        expected = str(kwargs.get("expected") or "")
+        chunks = _split_context_chunks(context)
+        if not chunks:
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: no retrieved context is available. "
+                    "ContextRecallScorer measures how much of the reference the "
+                    "retrieval supplied; without context there is nothing to "
+                    "assess."
+                ),
+                details={
+                    "skipped": "empty_context",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                },
+                assessed=False,
+            )
+        if not (input or "").strip():
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: no user query available. Context recall asks "
+                    "whether the retrieved chunks supply the information the "
+                    "query needs; with a blank query there is nothing to "
+                    "measure recall against."
+                ),
+                details={
+                    "skipped": "empty_query",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                },
+                assessed=False,
+            )
+        if not expected.strip():
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: no reference answer available on this row. "
+                    "Context recall measures the retrieved set against the "
+                    "information a correct answer needs; without a reference "
+                    "there is nothing to measure against. Add a reference "
+                    "answer or reference context to assess recall on this row."
+                ),
+                details={
+                    "skipped": "missing_reference",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                },
+                assessed=False,
+            )
+
+        prompts = self._get_prompts()
+        # The judge reads the same rendered chunk envelopes the scorer counts,
+        # and the reference answer verbatim: both anchors are checked against
+        # exactly what the judge was shown.
+        parsed_context = _render_context_chunks(chunks)
+        user_prompt = prompts["template"].format(
+            input=input,
+            context=parsed_context,
+            expected=expected,
+        )
+        result = self._call_judge(prompts["system"], user_prompt)
+        if not isinstance(result, dict):
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge reply was valid JSON but not an "
+                    "object, so it carries no reference items. Inspect "
+                    "details.judge_response to see what the judge returned."
+                ),
+                details={
+                    "skipped": "judge_parse_failure",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                    "judge_response": _sanitize_judge_value(result),
+                    "total_chunks": len(chunks),
+                },
+                assessed=False,
+            )
+
+        judge_score = _advisory_judge_score(result.get("score"))
+
+        valid_items: list[dict[str, Any]] = []
+        seen_spans: set[str] = set()
+        duplicate_spans: list[str] = []
+        discarded_items = 0
+        unverified_support_items = 0
+        raw_items = result.get("reference_items")
+        if isinstance(raw_items, list):
+            for item in raw_items:
+                if not isinstance(item, dict):
+                    discarded_items += 1
+                    continue
+                raw_reference_span = item.get("reference_span")
+                if not isinstance(raw_reference_span, str):
+                    discarded_items += 1
+                    continue
+                reference_span = _verbatim_span(raw_reference_span, expected)
+                if not reference_span:
+                    discarded_items += 1
+                    continue
+                if reference_span in seen_spans:
+                    duplicate_spans.append(reference_span)
+                    discarded_items += 1
+                    continue
+                seen_spans.add(reference_span)
+                supported = item.get("supported")
+                if not isinstance(supported, bool):
+                    discarded_items += 1
+                    continue
+                context_span = ""
+                if supported:
+                    raw_context_span = item.get("context_span")
+                    if isinstance(raw_context_span, str):
+                        context_span = (
+                            _verbatim_span(raw_context_span, parsed_context) or ""
+                        )
+                    if not context_span:
+                        # The judge claims support but cannot show it in the
+                        # retrieved chunks. Downgrade rather than trust it.
+                        supported = False
+                        unverified_support_items += 1
+                valid_items.append(
+                    {
+                        "reference_span": reference_span,
+                        "supported": supported,
+                        "context_span": context_span,
+                        "reason": str(item.get("reason", "")),
+                    }
+                )
+
+        if duplicate_spans:
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge listed the same reference span more "
+                    "than once, which would double-count that piece of "
+                    "information in the recall denominator. Inspect "
+                    "details.judge_response to see what the judge returned."
+                ),
+                details={
+                    "skipped": "judge_parse_failure",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                    "judge_response": _sanitize_judge_value(result),
+                    "total_chunks": len(chunks),
+                    "duplicate_reference_spans": sorted(set(duplicate_spans)),
+                    "discarded_items": discarded_items,
+                },
+                assessed=False,
+            )
+
+        if not valid_items:
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge returned no reference piece that "
+                    "could be verified as verbatim text of the reference "
+                    "answer. Inspect details.judge_response to see what the "
+                    "judge returned."
+                ),
+                details={
+                    "skipped": "judge_parse_failure",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                    "judge_response": _sanitize_judge_value(result),
+                    "total_chunks": len(chunks),
+                    "discarded_items": discarded_items,
+                },
+                assessed=False,
+            )
+
+        supported_count = sum(1 for item in valid_items if item["supported"])
+        recall = supported_count / len(valid_items)
+        explanation = (
+            f"{supported_count} of {len(valid_items)} reference piece(s) "
+            f"supplied; recall {recall:.2f}, threshold {self.threshold}."
+        )
+
+        return ScorerResult(
+            score=recall,
+            passed=ScoreNormalizer.apply_threshold(recall, self.threshold),
+            category=self.category,
+            explanation=explanation,
+            details={
+                "scorer_name": self.name,
+                "raw_score": recall,
+                "max_score": 1,
+                "judge_model": self.model,
+                "reference_items": valid_items,
+                "supported_items": supported_count,
+                "total_items": len(valid_items),
+                "unverified_support_items": unverified_support_items,
+                "discarded_items": discarded_items,
+                "judge_score": judge_score,
+                "judge_explanation": str(result.get("explanation", "")),
+            },
+        )
+
+
 class FairnessJudge(LLMJudgeScorer):
     """Evaluates fairness, bias, and discrimination (MIT-1.1)."""
 

--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -983,9 +983,16 @@ class ContextPrecisionScorer(LLMJudgeScorer):
     information is the needed one, and every later chunk repeating it is not
     needed, so identical chunks cannot both be marked needed. Exact
     duplicates are mechanically decidable, so the scorer enforces that rule
-    itself: a later exact duplicate of an earlier chunk is demoted to
-    ``not_needed`` even when the judge marked it needed, and every demotion
-    is recorded in ``details["duplicate_chunk_corrections"]``.
+    itself: within a group of identical chunks, if any copy is marked needed
+    the lowest-index copy is the one that supplies the information -- a later
+    copy marked needed is demoted to ``not_needed``, and a lowest-index copy
+    marked ``not_needed`` while a later copy is needed is promoted to
+    ``needed`` -- and every correction is recorded in
+    ``details["duplicate_chunk_corrections"]``. A group no copy is needed in
+    stays as judged: the information being supplied twice does not make it
+    needed once. Chunks are grouped by their passage content without the
+    leading ``[source-id]`` label, so the same passage retrieved under two
+    source IDs still groups as duplicates.
 
     Verdicts that are not dicts, carry a non-integer ``chunk_index``, or an
     unrecognized label are discarded and reported in
@@ -1164,15 +1171,27 @@ class ContextPrecisionScorer(LLMJudgeScorer):
 
         # Exact duplicates are mechanically decidable, so the prompt's
         # lowest-index rule is enforced here rather than trusted to the judge:
-        # within a group of chunks with identical content only the lowest
-        # index can be needed, and a later copy marked needed is demoted and
-        # recorded. Without this, a judge marking both copies of a duplicated
-        # chunk needed would score perfect precision. Chunks are grouped by
-        # whitespace-collapsed content, so delimiter padding around a ``---``
-        # fallback chunk does not hide the duplication.
+        # within a group of chunks with identical content, if any copy is
+        # marked needed the lowest-index copy is the one that supplies the
+        # information. A later copy marked needed is demoted, and a
+        # lowest-index copy marked not_needed while a later copy is needed is
+        # promoted, so the contradiction resolves to the documented rule in
+        # both verdict directions; every correction is recorded. Without this,
+        # a judge marking both copies of a duplicated chunk needed would score
+        # perfect precision, and marking the first copy not_needed with a
+        # later copy needed would zero the score instead of letting the
+        # lowest-index copy supply the information. Chunks are grouped by
+        # passage content without the leading source label, so identical
+        # passages under different source IDs still group as duplicates, and
+        # whitespace is collapsed, so delimiter padding around a ``---``
+        # fallback chunk does not hide the duplication either.
         content_groups: dict[str, list[int]] = {}
         for index in range(len(chunks)):
-            normalized_chunk = _normalized_text_with_offsets(chunks[index])[0].strip()
+            leading_label = _SOURCE_LABEL_PATTERN.match(chunks[index])
+            passage_start = leading_label.end() if leading_label else 0
+            normalized_chunk = _normalized_text_with_offsets(
+                chunks[index][passage_start:]
+            )[0].strip()
             content_groups.setdefault(normalized_chunk, []).append(index)
         needed_by_index: dict[int, str] = {
             index: str(valid_verdicts[index].get("needed"))
@@ -1180,20 +1199,29 @@ class ContextPrecisionScorer(LLMJudgeScorer):
         }
         duplicate_chunk_corrections: list[dict[str, Any]] = []
         for indexes in content_groups.values():
-            for index in indexes[1:]:
-                if needed_by_index[index] == "needed":
-                    needed_by_index[index] = "not_needed"
-                    duplicate_chunk_corrections.append(
-                        {
-                            "chunk_index": index,
-                            "duplicate_of": indexes[0],
-                            "reason": (
-                                "Exact duplicate of chunk "
-                                f"{indexes[0]}; the lowest-index chunk "
-                                "supplies the information."
-                            ),
-                        }
-                    )
+            if all(needed_by_index[index] == "not_needed" for index in indexes):
+                continue
+            for position, index in enumerate(indexes):
+                documented_label = "needed" if position == 0 else "not_needed"
+                if needed_by_index[index] == documented_label:
+                    continue
+                needed_by_index[index] = documented_label
+                duplicate_chunk_corrections.append(
+                    {
+                        "chunk_index": index,
+                        "duplicate_of": indexes[0],
+                        "reason": (
+                            "Exact duplicate of chunk "
+                            f"{indexes[0]}; the lowest-index chunk "
+                            "supplies the information."
+                        )
+                        if position > 0
+                        else (
+                            "Lowest-index copy of an exact-duplicate group; "
+                            "the lowest-index chunk supplies the information."
+                        ),
+                    }
+                )
 
         needed_count = sum(1 for label in needed_by_index.values() if label == "needed")
         precision = needed_count / len(chunks)
@@ -1268,14 +1296,19 @@ class ContextRecallScorer(LLMJudgeScorer):
       omitting the pieces the retrieval missed -- a two-fact reference where
       only the supported fact is listed would score a perfect recall.
 
-    The score is ``supported regions / regions``, derived from the validated
-    pieces: adjacent pieces sharing a verdict are merged into maximal stretches
-    of the reference first, so the score depends on which parts of the
-    reference are supplied, not on how the judge happened to partition it --
-    two replies that make the same supported / not-supported claim over the
-    reference score identically. The judge's own overall score is advisory and
-    recorded in ``details["judge_score"]``. A reply that yields no valid piece
-    is a parse failure rather than a perfect or empty score.
+    The score is the share of the reference text the retrieval supplied:
+    supported stretch length over total stretch length, measured on the
+    whitespace-collapsed reference the pieces are bound to. Adjacent pieces
+    sharing a verdict are merged into maximal stretches first, so splitting
+    or merging equivalent pieces leaves the stretches -- and the measured
+    lengths -- unchanged, and weighing the stretches by length is what makes
+    recall fall as more distinct reference information goes unsupplied,
+    where a count of same-verdict runs would freeze at 0.5 no matter how
+    many facts the retrieval missed. Gaps between opposite-verdict stretches
+    stay outside both, so the denominator is the stretches' own total
+    length, not the whole reference. The judge's own overall score is
+    advisory and recorded in ``details["judge_score"]``. A reply that yields
+    no valid piece is a parse failure rather than a perfect or empty score.
 
     Rows without retrieved context, with a blank query, or without a reference
     answer return ``assessed=False`` (``skipped`` is ``empty_context`` /
@@ -1574,30 +1607,36 @@ class ContextRecallScorer(LLMJudgeScorer):
                 assessed=False,
             )
 
-        # Adjacent pieces sharing a verdict are merged into maximal stretches
-        # of the reference before scoring: the score depends on which parts of
-        # the reference are supplied, not on how the judge happened to
-        # partition it. Two replies that make the same supported /
-        # not-supported claim over the reference -- one listing a whole
-        # sentence, the other splitting it into words -- score identically,
-        # because the decomposition check has already pinned every gap between
-        # bound pieces to whitespace.
-        ordered: list[tuple[tuple[int, int], bool]] = sorted(
+        # The score weighs maximal same-verdict stretches of the reference by
+        # their length on the whitespace-collapsed text: supported stretch
+        # length over total stretch length. Piece count would move with the
+        # judge's partition -- splitting one unsupported sentence into three
+        # pieces would triple the penalty -- and counting runs without their
+        # length would freeze the score at 0.5 while any number of distinct
+        # facts goes unsupplied. Measuring stretch length does neither:
+        # splitting or merging equivalent pieces leaves the stretches, and so
+        # their measured lengths, unchanged, while every additional unsupplied
+        # fact adds reference length the retrieval did not supply. Merging
+        # same-verdict neighbours first is what makes the split invariance
+        # exact: the whitespace gaps the decomposition check allows must not
+        # leak out of the measurement when a supported sentence is split into
+        # words. Gaps between opposite-verdict stretches stay outside both, so
+        # the denominator is the stretches' own length, not the whole
+        # reference.
+        stretches: list[tuple[int, int, bool]] = []
+        for interval, supported_flag in sorted(
             zip(item_intervals, (bool(item["supported"]) for item in valid_items))
-        )
-        total_regions = 0
-        supported_regions = 0
-        previous_supported: bool | None = None
-        for _interval, supported_flag in ordered:
-            if supported_flag != previous_supported:
-                total_regions += 1
-                if supported_flag:
-                    supported_regions += 1
-            previous_supported = supported_flag
+        ):
+            if stretches and stretches[-1][2] == supported_flag:
+                stretches[-1] = (stretches[-1][0], interval[1], supported_flag)
+            else:
+                stretches.append((interval[0], interval[1], supported_flag))
+        supported_length = sum(end - start for start, end, flag in stretches if flag)
+        total_length = sum(end - start for start, end, _flag in stretches)
 
-        recall = supported_regions / total_regions
+        recall = supported_length / total_length
         explanation = (
-            f"{supported_regions} of {total_regions} reference region(s) "
+            f"{supported_length} of {total_length} reference character(s) "
             f"supplied; recall {recall:.2f}, threshold {self.threshold}."
         )
 
@@ -1612,8 +1651,8 @@ class ContextRecallScorer(LLMJudgeScorer):
                 "max_score": 1,
                 "judge_model": self.model,
                 "reference_items": valid_items,
-                "supported_regions": supported_regions,
-                "total_regions": total_regions,
+                "supported_span_length": supported_length,
+                "total_span_length": total_length,
                 "unverified_support_items": unverified_support_items,
                 "discarded_items": discarded_items,
                 "judge_score": judge_score,

--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -519,6 +519,115 @@ def _render_context_chunks(chunks: list[str]) -> str:
     )
 
 
+def _xml_unescape_prompt_text(text: str) -> str:
+    """Reverse ``_escape_chunk_content`` on a span the judge quoted back.
+
+    The judge reads XML-escaped chunk content, so its quotes can arrive in
+    escaped form (``R&amp;D`` for ``R&D``). Verification must happen against
+    the original chunk text, so the quote is unescaped first. The order is
+    the reverse of escaping: entities for ``<`` and ``>`` are resolved before
+    ``&amp;``, so a chunk that legitimately contained ``&amp;`` round-trips
+    (shown as ``&amp;amp;``, quoted back, unescaped once to ``&amp;``).
+    """
+    return text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
+
+
+_ENVELOPE_OR_LABEL_PATTERN = re.compile(r"\[[^\[\]]*\]|</?chunk\b[^>]*>")
+
+
+def _is_envelope_or_label_only(span: str) -> bool:
+    """Return True when a quoted span carries no chunk content, only syntax.
+
+    A ``<chunk index="N">`` envelope marker or a ``[source-id]`` label is part
+    of the prompt scaffolding (or, for a label, the chunk's first token), not
+    evidence that the retrieval supplied a piece of information. A span made
+    up solely of such markers -- or of whitespace around them -- verifies
+    nothing, even when the text is genuinely present in a chunk.
+    """
+    return not _ENVELOPE_OR_LABEL_PATTERN.sub("", span).strip()
+
+
+def _context_span_in_chunks(span: str, chunks: list[str]) -> str:
+    """Verify a quoted span against the original chunk content, not the prompt.
+
+    Returns the span verbatim as it appears in the matching original chunk, or
+    "" when no chunk contains it. Matching against a single original chunk
+    (rather than the rendered envelope sequence) keeps evidence anchored to
+    what was actually retrieved and cannot be satisfied by envelope syntax.
+    """
+    for chunk in chunks:
+        verified = _verbatim_span(span, chunk)
+        if verified:
+            return verified
+    return ""
+
+
+def _normalized_occurrences(span: str, normalized_row: str) -> list[tuple[int, int]]:
+    """All (start, end) occurrences of a span in the normalized row text.
+
+    Coordinates refer to the whitespace-collapsed, quote-normalized text
+    produced by ``_normalized_text_with_offsets``.
+    """
+    normalized_span, _ = _normalized_text_with_offsets(span)
+    if not normalized_span:
+        return []
+    occurrences: list[tuple[int, int]] = []
+    start = normalized_row.find(normalized_span)
+    while start >= 0:
+        occurrences.append((start, start + len(normalized_span)))
+        start = normalized_row.find(normalized_span, start + 1)
+    return occurrences
+
+
+def _check_reference_decomposition(
+    reference_spans: list[str], expected: str
+) -> tuple[list[str], list[str]]:
+    """Check that verbatim reference spans tile the whole reference answer.
+
+    Returns ``(overlapping_spans, uncovered_texts)``; both empty means the
+    spans form a complete, non-overlapping decomposition: every piece of the
+    reference is listed by exactly one item. Whitespace between pieces does
+    not break completeness. Anything else is a judge that trimmed the
+    denominator (omitted pieces) or listed the same text twice under
+    overlapping spans -- either way the recall score would be inflated, so
+    the caller fails the parse.
+    """
+    normalized_expected, offsets = _normalized_text_with_offsets(expected)
+    intervals: list[tuple[int, int, str]] = []
+    for span in reference_spans:
+        for start, end in _normalized_occurrences(span, normalized_expected):
+            intervals.append((start, end, span))
+    intervals.sort()
+
+    overlapping: set[str] = set()
+    active_end = -1
+    active_span = ""
+    for start, end, span in intervals:
+        # Same-span intervals are repeated occurrences of one item's piece,
+        # not ambiguity; distinct spans that intersect are (both intervals
+        # are sorted by start, so an active interval that reaches past the
+        # current start genuinely overlaps it).
+        if active_span and start < active_end and span != active_span:
+            overlapping.add(active_span)
+            overlapping.add(span)
+        if end > active_end:
+            active_end, active_span = end, span
+
+    uncovered: list[str] = []
+    covered_end = 0
+    for start, end, _ in intervals:
+        if start > covered_end:
+            gap = normalized_expected[covered_end:start]
+            if gap.strip():
+                uncovered.append(expected[offsets[covered_end] : offsets[start]])
+        covered_end = max(covered_end, end)
+    if covered_end < len(normalized_expected):
+        gap = normalized_expected[covered_end:]
+        if gap.strip():
+            uncovered.append(expected[offsets[covered_end] : offsets[-1]])
+    return sorted(overlapping), uncovered
+
+
 class RetrievalRelevanceScorer(LLMJudgeScorer):
     """Judge whether each retrieved context chunk is relevant to the user query.
 
@@ -858,6 +967,12 @@ class ContextPrecisionScorer(LLMJudgeScorer):
     score as ``needed / total`` from the validated verdicts. The judge's own
     overall score is advisory and recorded in ``details["judge_score"]``.
 
+    When two chunks carry the same information, "another chunk supplies it"
+    would otherwise apply symmetrically to both copies. The prompt fixes the
+    tie-break deterministically: the lowest-index chunk supplying the
+    information is the needed one, and every later chunk repeating it is not
+    needed, so identical chunks cannot both be marked needed.
+
     Verdicts that are not dicts, carry a non-integer ``chunk_index``, or an
     unrecognized label are discarded and reported in
     ``details["discarded_verdicts"]``. A duplicated or out-of-range
@@ -1082,17 +1197,26 @@ class ContextRecallScorer(LLMJudgeScorer):
 
     The judge decomposes the row's reference answer (``expected``) into
     individual pieces of information, each anchored to a verbatim span of the
-    reference, and marks each piece ``supported`` or ``not_supported`` with a
+    reference, and marks each piece with a boolean ``supported`` flag and a
     verbatim context span as evidence. The scorer validates those anchors:
 
     - A piece whose reference span is not verbatim in ``expected`` is discarded,
       so a judge cannot invent information the reference does not contain.
     - A piece whose ``supported`` flag is not a boolean is discarded.
-    - A ``supported`` piece whose context span is not verbatim in the rendered
-      chunk sequence the judge read is counted as not supported, because the
-      support claim cannot be verified.
+    - A ``supported`` piece is verified against the original chunk content,
+      not the XML-escaped envelope view the judge read: the quoted span is
+      unescaped and matched back to a retrieved chunk, and the span stored in
+      the result is the original chunk text. A span that only repeats the
+      envelope marker or the chunk's source label is not evidence, and a
+      support claim that cannot be verified this way is counted as not
+      supported rather than trusted.
     - A duplicated reference span fails the parse: the same information listed
       twice would otherwise double-count in the denominator.
+    - The surviving pieces must form a complete, non-overlapping decomposition
+      of the reference: overlapping spans, or reference text no piece covers,
+      fail the parse. A judge could otherwise shrink the denominator by
+      omitting the pieces the retrieval missed -- a two-fact reference where
+      only the supported fact is listed would score a perfect recall.
 
     The score is ``supported / valid pieces``, derived from the validated items.
     The judge's own overall score is advisory and recorded in
@@ -1243,9 +1367,16 @@ class ContextRecallScorer(LLMJudgeScorer):
                 if supported:
                     raw_context_span = item.get("context_span")
                     if isinstance(raw_context_span, str):
-                        context_span = (
-                            _verbatim_span(raw_context_span, parsed_context) or ""
-                        )
+                        # The judge quotes from the XML-escaped envelope view,
+                        # so the quote is unescaped and verified against the
+                        # original chunk content -- never against the rendered
+                        # prompt, where escaping artifacts and envelope syntax
+                        # would verify as false evidence. The stored span is
+                        # the original chunk text, not the escaped quote.
+                        unescaped_span = _xml_unescape_prompt_text(raw_context_span)
+                        context_span = _context_span_in_chunks(unescaped_span, chunks)
+                        if context_span and _is_envelope_or_label_only(context_span):
+                            context_span = ""
                     if not context_span:
                         # The judge claims support but cannot show it in the
                         # retrieved chunks. Downgrade rather than trust it.
@@ -1300,6 +1431,62 @@ class ContextRecallScorer(LLMJudgeScorer):
                     "judge_model": self.model,
                     "judge_response": _sanitize_judge_value(result),
                     "total_chunks": len(chunks),
+                    "discarded_items": discarded_items,
+                },
+                assessed=False,
+            )
+
+        # The denominator must come from a complete, non-overlapping
+        # decomposition of the reference. A judge that omits the pieces the
+        # retrieval missed would otherwise shrink the denominator and score a
+        # partial retrieval as perfect (a two-fact reference where only the
+        # supported fact is listed scores 1.0), and overlapping spans would
+        # count the same reference text as separate pieces. Either way the
+        # denominator is not trustworthy, so the row is un-assessed.
+        overlapping_spans, uncovered_texts = _check_reference_decomposition(
+            [item["reference_span"] for item in valid_items], expected
+        )
+        if overlapping_spans:
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge's reference pieces overlap, so the "
+                    "same reference text would be counted more than once in "
+                    "the recall denominator. Inspect details.judge_response "
+                    "to see what the judge returned."
+                ),
+                details={
+                    "skipped": "judge_parse_failure",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                    "judge_response": _sanitize_judge_value(result),
+                    "total_chunks": len(chunks),
+                    "overlapping_reference_spans": overlapping_spans,
+                    "discarded_items": discarded_items,
+                },
+                assessed=False,
+            )
+        if uncovered_texts:
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation=(
+                    "Un-assessed: the judge's reference pieces do not cover "
+                    "the whole reference answer, so parts of it -- likely the "
+                    "pieces the retrieval missed -- are missing from the "
+                    "recall denominator. Inspect details.judge_response to "
+                    "see what the judge returned."
+                ),
+                details={
+                    "skipped": "judge_parse_failure",
+                    "scorer_name": self.name,
+                    "judge_model": self.model,
+                    "judge_response": _sanitize_judge_value(result),
+                    "total_chunks": len(chunks),
+                    "uncovered_reference_text": uncovered_texts,
                     "discarded_items": discarded_items,
                 },
                 assessed=False,

--- a/tests/test_context_precision_recall.py
+++ b/tests/test_context_precision_recall.py
@@ -141,6 +141,35 @@ def test_precision_redundant_chunk_reduces_score() -> None:
     assert result.details["total_chunks"] == 3
 
 
+def test_precision_identical_chunks_earliest_is_needed() -> None:
+    # Two otherwise identical chunks: the prompt's ordering rule marks the
+    # lowest-index chunk needed and the later duplicate not needed, so the
+    # tie is broken deterministically instead of by judge preference.
+    scorer = _precision_scorer(
+        {
+            "score": 2,
+            "explanation": "One chunk duplicates the other exactly.",
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "Lowest index supplying the figure."},
+                {"chunk_index": 1, "needed": "not_needed", "reason": "Identical duplicate of chunk 0."},
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Revenue was $10M.",
+        input="What was the revenue?",
+        context="Revenue was $10M --- Revenue was $10M",
+    )
+
+    assert result.assessed
+    assert result.score == 0.5
+    assert result.details["needed_chunks"] == 1
+    assert result.details["total_chunks"] == 2
+    assert result.details["chunk_verdicts"][0]["needed"] == "needed"
+    assert result.details["chunk_verdicts"][1]["needed"] == "not_needed"
+
+
 def test_precision_no_chunks_needed_scores_zero() -> None:
     scorer = _precision_scorer(
         {
@@ -811,10 +840,10 @@ def test_recall_unverifiable_context_span_downgrades_to_not_supported() -> None:
     assert result.details["reference_items"][0]["supported"] is False
 
 
-def test_recall_context_span_is_checked_against_the_rendered_chunks() -> None:
-    # The judge reads the XML-escaped chunk envelopes, so a chunk containing
-    # "&" is shown as "&amp;". A context span quoted from that view verifies;
-    # the raw form is not what the judge was shown and does not.
+def test_recall_context_span_is_checked_against_original_chunk_content() -> None:
+    # Evidence is verified against the chunk's original text, not the escaped
+    # envelope view the judge read: a natural quote containing "&" verifies,
+    # and the span stored in the result is the original chunk text.
     scorer = _recall_scorer(
         {
             "score": 3,
@@ -822,8 +851,8 @@ def test_recall_context_span_is_checked_against_the_rendered_chunks() -> None:
                 {
                     "reference_span": "R&D spending was $2M.",
                     "supported": True,
-                    "context_span": "R&amp;D spending was $2M",
-                    "reason": "Quoted from the envelope.",
+                    "context_span": "R&D spending was $2M",
+                    "reason": "Quoted from the chunk text.",
                 },
             ],
         }
@@ -838,7 +867,104 @@ def test_recall_context_span_is_checked_against_the_rendered_chunks() -> None:
 
     assert result.assessed
     assert result.score == 1.0
-    assert result.details["reference_items"][0]["context_span"] == "R&amp;D spending was $2M"
+    stored = result.details["reference_items"][0]["context_span"]
+    assert stored == "R&D spending was $2M"
+    assert "&amp;" not in stored
+
+
+def test_recall_escaped_prompt_quote_maps_back_to_original_text() -> None:
+    # The judge reads XML-escaped chunk content, so its quote can arrive in
+    # escaped form. The quote is unescaped and matched against the original
+    # chunk text, and the original text -- not the escaped quote -- is stored.
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "R&D spending was $2M.",
+                    "supported": True,
+                    "context_span": "R&amp;D spending was $2M",
+                    "reason": "Quoted from the escaped envelope.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "R&D spending was $2M.",
+        input="What was R&D spending?",
+        context="[doc-1] R&D spending was $2M",
+        expected="R&D spending was $2M.",
+    )
+
+    assert result.assessed
+    assert result.score == 1.0
+    assert result.details["unverified_support_items"] == 0
+    stored = result.details["reference_items"][0]["context_span"]
+    assert stored == "R&D spending was $2M"
+    assert "&amp;" not in stored
+
+
+def test_recall_envelope_only_span_is_not_evidence() -> None:
+    # A quoted span that only repeats the envelope marker verifies nothing:
+    # the envelope is prompt scaffolding, not retrieved information.
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": True,
+                    "context_span": '<chunk index="0">',
+                    "reason": "Quoted the envelope instead of the chunk.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert result.assessed
+    assert result.score == 0.0
+    assert result.details["unverified_support_items"] == 1
+    assert result.details["reference_items"][0]["supported"] is False
+    assert result.details["reference_items"][0]["context_span"] == ""
+
+
+def test_recall_source_label_only_span_is_not_evidence() -> None:
+    # The chunk's [source-id] label is part of the chunk text, so a label-only
+    # quote does verify verbatim -- but it is scaffolding, not evidence, so
+    # the support claim is still downgraded.
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": True,
+                    "context_span": "[doc-1]",
+                    "reason": "Quoted the source label only.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert result.assessed
+    assert result.score == 0.0
+    assert result.details["unverified_support_items"] == 1
+    assert result.details["reference_items"][0]["supported"] is False
 
 
 def test_recall_duplicate_reference_span_is_a_parse_failure() -> None:
@@ -876,31 +1002,132 @@ def test_recall_duplicate_reference_span_is_a_parse_failure() -> None:
     assert result.details["duplicate_reference_spans"] == ["Growth was 12%."]
 
 
-def test_recall_non_boolean_supported_flag_is_discarded() -> None:
+def test_recall_omitted_fact_is_a_parse_failure() -> None:
+    # The recall denominator must come from a complete decomposition of the
+    # reference. A judge that lists only the supported fact of a two-fact
+    # reference would otherwise score a partial retrieval as perfect.
     scorer = _recall_scorer(
         {
             "score": 3,
+            "explanation": "Everything was retrieved.",
             "reference_items": [
                 {
-                    "reference_span": "Growth was 12%.",
-                    "supported": "yes",
-                    "context_span": "Growth was 12%.",
-                    "reason": "String flag.",
+                    "reference_span": "Revenue was $10 million.",
+                    "supported": True,
+                    "context_span": "Revenue was $10 million.",
+                    "reason": "Stated verbatim.",
                 },
             ],
         }
     )
 
     result = scorer.score(
-        "Growth was 12%.",
-        input="What was the growth?",
-        context="[doc-1] Growth was 12%.",
-        expected="Growth was 12%.",
+        "Revenue was $10 million.",
+        input="What was the revenue and growth?",
+        context="[doc-1] Revenue was $10 million.",
+        expected="Revenue was $10 million. Growth was 12%.",
     )
 
     assert not result.assessed
     assert result.details["skipped"] == "judge_parse_failure"
-    assert result.details["discarded_items"] == 1
+    assert result.details["uncovered_reference_text"] == [" Growth was 12%."]
+    assert "judge_response" in result.details
+
+
+def test_recall_overlapping_reference_spans_are_a_parse_failure() -> None:
+    # Overlapping or nested spans would count the same reference text as
+    # separate pieces in the denominator, so the decomposition is ambiguous
+    # and the row is un-assessed.
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "Revenue was $10 million.",
+                    "supported": True,
+                    "context_span": "Revenue was $10 million.",
+                    "reason": "Stated verbatim.",
+                },
+                {
+                    "reference_span": "was $10 million",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Nested in the first piece.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Revenue was $10 million.",
+        input="What was the revenue?",
+        context="[doc-1] Revenue was $10 million.",
+        expected="Revenue was $10 million.",
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert "overlapping_reference_spans" in result.details
+
+
+def test_recall_non_boolean_supported_flag_is_discarded() -> None:
+    # Only JSON Booleans are accepted. String labels ("supported",
+    # "not_supported"), numeric stand-ins, and nulls are discarded -- a string
+    # label from a misread prompt must never count as a verdict.
+    for bad_flag in ("supported", "not_supported", "yes", 1, None):
+        scorer = _recall_scorer(
+            {
+                "score": 3,
+                "reference_items": [
+                    {
+                        "reference_span": "Growth was 12%.",
+                        "supported": bad_flag,
+                        "context_span": "Growth was 12%.",
+                        "reason": "Non-boolean flag.",
+                    },
+                ],
+            }
+        )
+
+        result = scorer.score(
+            "Growth was 12%.",
+            input="What was the growth?",
+            context="[doc-1] Growth was 12%.",
+            expected="Growth was 12%.",
+        )
+
+        assert not result.assessed, bad_flag
+        assert result.details["skipped"] == "judge_parse_failure", bad_flag
+        assert result.details["discarded_items"] == 1, bad_flag
+
+
+def test_recall_boolean_flags_are_accepted() -> None:
+    # Both Boolean values are valid verdicts: true counts as supported when
+    # the context span verifies, false counts as not supported outright.
+    for flag, expected_score in ((True, 1.0), (False, 0.0)):
+        scorer = _recall_scorer(
+            {
+                "score": 3,
+                "reference_items": [
+                    {
+                        "reference_span": "Growth was 12%.",
+                        "supported": flag,
+                        "context_span": "Growth was 12%." if flag else "",
+                        "reason": "Boolean flag.",
+                    },
+                ],
+            }
+        )
+
+        result = scorer.score(
+            "Growth was 12%.",
+            input="What was the growth?",
+            context="[doc-1] Growth was 12%.",
+            expected="Growth was 12%.",
+        )
+
+        assert result.assessed, flag
+        assert result.score == expected_score, flag
 
 
 def test_recall_non_dict_items_are_discarded() -> None:
@@ -1017,3 +1244,24 @@ def test_recall_template_json_example_is_parseable() -> None:
     assert payload["reference_items"][0]["reference_span"] == "ref"
     assert payload["reference_items"][0]["supported"] is True
     assert payload["reference_items"][0]["context_span"] == "ctx"
+
+
+def test_recall_template_requires_boolean_supported_field() -> None:
+    # The prose and the JSON schema must agree: "supported" is a JSON Boolean,
+    # so the old string labels must not appear as verdict values anywhere in
+    # the prompt (the JSON example's "supported" key is the field name, not a
+    # label).
+    recall = JUDGE_PROMPTS["ContextRecallScorer"]
+    for text in recall.values():
+        assert '"not_supported"' not in text
+        assert '- "supported"' not in text
+    assert "Boolean" in recall["template"]
+
+
+def test_precision_template_defines_duplicate_chunk_ordering() -> None:
+    # "Another chunk supplies the same information" applies symmetrically to
+    # identical chunks, so the prompt must fix the tie-break: the
+    # lowest-index chunk is needed, later duplicates are not.
+    precision = JUDGE_PROMPTS["ContextPrecisionScorer"]
+    for text in precision.values():
+        assert "lowest chunk_index" in text or "lowest chunk index" in text

--- a/tests/test_context_precision_recall.py
+++ b/tests/test_context_precision_recall.py
@@ -170,6 +170,46 @@ def test_precision_identical_chunks_earliest_is_needed() -> None:
     assert result.details["chunk_verdicts"][1]["needed"] == "not_needed"
 
 
+def test_precision_identical_chunks_both_needed_are_demoted() -> None:
+    # The prompt's lowest-index rule is enforced by the scorer itself: a judge
+    # marking both copies of an exact duplicate needed is corrected, not
+    # rewarded with perfect precision. The --- delimiter leaves whitespace
+    # padding on each chunk, so grouping must see through it.
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "explanation": "Both chunks supply the figure.",
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "States the figure."},
+                {"chunk_index": 1, "needed": "needed", "reason": "Also states the figure."},
+            ],
+        }
+    )
+
+    scorer.threshold = 0.7
+    result = scorer.score(
+        "Revenue was $10M.",
+        input="What was the revenue?",
+        context="Revenue was $10M --- Revenue was $10M",
+    )
+
+    assert result.assessed
+    assert result.score == 0.5
+    assert result.details["needed_chunks"] == 1
+    assert result.details["chunk_verdicts"][0]["needed"] == "needed"
+    assert result.details["chunk_verdicts"][1]["needed"] == "not_needed"
+    assert result.details["duplicate_chunk_corrections"] == [
+        {
+            "chunk_index": 1,
+            "duplicate_of": 0,
+            "reason": (
+                "Exact duplicate of chunk 0; the lowest-index chunk "
+                "supplies the information."
+            ),
+        }
+    ]
+
+
 def test_precision_no_chunks_needed_scores_zero() -> None:
     scorer = _precision_scorer(
         {
@@ -595,8 +635,9 @@ def test_recall_all_items_supported_scores_one() -> None:
     assert result.assessed
     assert result.score == 1.0
     assert result.passed
-    assert result.details["supported_items"] == 2
-    assert result.details["total_items"] == 2
+    # Adjacent supported pieces merge into one supplied region.
+    assert result.details["supported_regions"] == 1
+    assert result.details["total_regions"] == 1
 
 
 def test_recall_missing_item_reduces_score() -> None:
@@ -627,6 +668,7 @@ def test_recall_missing_item_reduces_score() -> None:
         }
     )
 
+    scorer.threshold = 0.7
     result = scorer.score(
         "Revenue was $10 million.",
         input="Summarize the quarter.",
@@ -635,10 +677,90 @@ def test_recall_missing_item_reduces_score() -> None:
     )
 
     assert result.assessed
-    assert result.score == 1 / 3
+    assert result.score == 1 / 2
     assert not result.passed
-    assert result.details["supported_items"] == 1
-    assert result.details["total_items"] == 3
+    # The two unsupported sentences are adjacent, so they merge into one
+    # unsupplied region: the judge could equally have listed them as a single
+    # piece, and the score must not depend on that choice.
+    assert result.details["supported_regions"] == 1
+    assert result.details["total_regions"] == 2
+
+
+def test_recall_score_is_invariant_to_equivalent_splits() -> None:
+    # Two replies that decompose the same reference differently but make the
+    # same supported / not-supported claim over it must score identically.
+    reference = "Alpha beta gamma. Delta epsilon."
+    context = "[doc-1] Alpha beta gamma."
+
+    sentence_level = _recall_scorer(
+        {
+            "score": 2,
+            "explanation": "First sentence retrieved.",
+            "reference_items": [
+                {
+                    "reference_span": "Alpha beta gamma.",
+                    "supported": True,
+                    "context_span": "Alpha beta gamma.",
+                    "reason": "Supplied verbatim.",
+                },
+                {
+                    "reference_span": "Delta epsilon.",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Not in the retrieved chunks.",
+                },
+            ],
+        }
+    ).score(
+        "Alpha beta gamma.",
+        input="What are the values?",
+        context=context,
+        expected=reference,
+    )
+
+    word_level = _recall_scorer(
+        {
+            "score": 2,
+            "explanation": "First sentence retrieved.",
+            "reference_items": [
+                {
+                    "reference_span": "Alpha",
+                    "supported": True,
+                    "context_span": "Alpha",
+                    "reason": "Supplied verbatim.",
+                },
+                {
+                    "reference_span": "beta",
+                    "supported": True,
+                    "context_span": "beta",
+                    "reason": "Supplied verbatim.",
+                },
+                {
+                    "reference_span": "gamma.",
+                    "supported": True,
+                    "context_span": "gamma.",
+                    "reason": "Supplied verbatim.",
+                },
+                {
+                    "reference_span": "Delta epsilon.",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Not in the retrieved chunks.",
+                },
+            ],
+        }
+    ).score(
+        "Alpha beta gamma.",
+        input="What are the values?",
+        context=context,
+        expected=reference,
+    )
+
+    assert sentence_level.assessed
+    assert word_level.assessed
+    assert sentence_level.score == word_level.score == 0.5
+    assert sentence_level.details["total_regions"] == 2
+    assert word_level.details["total_regions"] == 2
 
 
 def test_recall_no_items_supported_scores_zero() -> None:
@@ -762,7 +884,7 @@ def test_recall_fabricated_reference_span_is_discarded() -> None:
 
     assert result.assessed
     assert result.details["discarded_items"] == 1
-    assert result.details["total_items"] == 1
+    assert result.details["total_regions"] == 1
     assert result.score == 1.0
 
 
@@ -836,7 +958,7 @@ def test_recall_unverifiable_context_span_downgrades_to_not_supported() -> None:
     assert result.assessed
     assert result.score == 0.0
     assert result.details["unverified_support_items"] == 1
-    assert result.details["supported_items"] == 0
+    assert result.details["supported_regions"] == 0
     assert result.details["reference_items"][0]["supported"] is False
 
 
@@ -967,6 +1089,40 @@ def test_recall_source_label_only_span_is_not_evidence() -> None:
     assert result.details["reference_items"][0]["supported"] is False
 
 
+def test_recall_bracketed_content_is_not_treated_as_scaffolding() -> None:
+    # Bracketed text that is not the chunk's source label is chunk content: a
+    # quote of "[FDA]" is real evidence, not an envelope artifact. The
+    # scaffolding check only strips envelope markers and the matched chunk's
+    # own leading label.
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "explanation": "The agency was named.",
+            "reference_items": [
+                {
+                    "reference_span": "The [FDA] approved the drug.",
+                    "supported": True,
+                    "context_span": "[FDA]",
+                    "reason": "Names the agency verbatim.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "The [FDA] approved the drug.",
+        input="Which agency approved the drug?",
+        context="[doc-1] The [FDA] approved the drug.",
+        expected="The [FDA] approved the drug.",
+    )
+
+    assert result.assessed
+    assert result.score == 1.0
+    assert result.details["unverified_support_items"] == 0
+    assert result.details["reference_items"][0]["supported"] is True
+    assert result.details["reference_items"][0]["context_span"] == "[FDA]"
+
+
 def test_recall_duplicate_reference_span_is_a_parse_failure() -> None:
     # The same piece listed twice would double-count in the denominator, so
     # the item set is ambiguous and the row is un-assessed.
@@ -1000,6 +1156,74 @@ def test_recall_duplicate_reference_span_is_a_parse_failure() -> None:
     assert not result.assessed
     assert result.details["skipped"] == "judge_parse_failure"
     assert result.details["duplicate_reference_spans"] == ["Growth was 12%."]
+
+
+def test_recall_repeated_sentence_one_item_cannot_cover_both() -> None:
+    # A reference that repeats a sentence holds that piece of information
+    # twice: each item is bound to one occurrence, so listing the sentence
+    # once leaves the second occurrence uncovered and the row is un-assessed.
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "explanation": "Both copies were retrieved.",
+            "reference_items": [
+                {
+                    "reference_span": "Apply twice.",
+                    "supported": True,
+                    "context_span": "Apply twice.",
+                    "reason": "Only listing.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Apply twice. Apply twice.",
+        input="How do I apply it?",
+        context="[doc-1] Apply twice. Apply twice.",
+        expected="Apply twice. Apply twice.",
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert result.details["uncovered_reference_text"]
+
+
+def test_recall_repeated_sentence_scored_per_occurrence() -> None:
+    # Listing the repeated sentence once per occurrence is the honest
+    # decomposition: one supplied copy and one missing copy score 0.5.
+    scorer = _recall_scorer(
+        {
+            "score": 2,
+            "explanation": "One copy retrieved.",
+            "reference_items": [
+                {
+                    "reference_span": "Apply twice.",
+                    "supported": True,
+                    "context_span": "Apply twice.",
+                    "reason": "First copy.",
+                },
+                {
+                    "reference_span": "Apply twice.",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Second copy missing from context.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Apply twice. Apply twice.",
+        input="How do I apply it?",
+        context="[doc-1] Apply twice.",
+        expected="Apply twice. Apply twice.",
+    )
+
+    assert result.assessed
+    assert result.score == 0.5
+    assert result.details["supported_regions"] == 1
+    assert result.details["total_regions"] == 2
 
 
 def test_recall_omitted_fact_is_a_parse_failure() -> None:
@@ -1156,7 +1380,7 @@ def test_recall_non_dict_items_are_discarded() -> None:
 
     assert result.assessed
     assert result.details["discarded_items"] == 2
-    assert result.details["total_items"] == 1
+    assert result.details["total_regions"] == 1
 
 
 def test_recall_non_object_json_reply_is_controlled_unassessed() -> None:

--- a/tests/test_context_precision_recall.py
+++ b/tests/test_context_precision_recall.py
@@ -1,0 +1,1019 @@
+# SPDX-FileCopyrightText: 2026 Zeming-Yuan
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+import json
+import re
+from unittest.mock import Mock
+
+from rai_toolkit.prompts.judge_prompts import JUDGE_PROMPTS
+from rai_toolkit.scorers import ContextPrecisionScorer, ContextRecallScorer
+
+
+def _precision_scorer(result: object) -> ContextPrecisionScorer:
+    scorer = ContextPrecisionScorer(api_key="test")
+    scorer._call_judge = Mock(return_value=result)
+    return scorer
+
+
+def _recall_scorer(result: object) -> ContextRecallScorer:
+    scorer = ContextRecallScorer(api_key="test")
+    scorer._call_judge = Mock(return_value=result)
+    return scorer
+
+
+# --------------------------------------------------------------------------
+# ContextPrecisionScorer: skip paths
+# --------------------------------------------------------------------------
+
+
+def test_precision_missing_context_is_unassessed_without_calling_judge() -> None:
+    scorer = _precision_scorer({"score": 3})
+
+    result = scorer.score("A response", context="  ")
+
+    assert not result.assessed
+    assert result.details["skipped"] == "empty_context"
+    scorer._call_judge.assert_not_called()
+
+
+def test_precision_delimiter_only_context_is_unassessed_without_calling_judge() -> None:
+    scorer = _precision_scorer({"score": 3})
+
+    result = scorer.score("A response", input="What is the revenue?", context=" --- --- ")
+
+    assert not result.assessed
+    assert result.details["skipped"] == "empty_context"
+    scorer._call_judge.assert_not_called()
+
+
+def test_precision_blank_query_is_unassessed_without_calling_judge() -> None:
+    scorer = _precision_scorer({"score": 3})
+
+    result = scorer.score("A response", input="   ", context="Chunk A --- Chunk B")
+
+    assert not result.assessed
+    assert result.details["skipped"] == "empty_query"
+    scorer._call_judge.assert_not_called()
+
+
+def test_precision_refusal_shaped_expected_is_still_assessed() -> None:
+    # This scorer grades the retriever, not the generator: a refusal-shaped
+    # expected value must not skip the row, because the retrieved context is
+    # gradable even when the generator declines to answer.
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "Has the figure."},
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "I can't provide private account data.",
+        input="Show me private account data",
+        context="[doc-1] Account data is restricted.",
+        expected="Refuse to reveal private account data.",
+    )
+
+    assert result.assessed
+    scorer._call_judge.assert_called_once()
+    assert "skipped" not in result.details
+
+
+# --------------------------------------------------------------------------
+# ContextPrecisionScorer: scoring
+# --------------------------------------------------------------------------
+
+
+def test_precision_all_chunks_needed_scores_one() -> None:
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "explanation": "Both chunks were needed.",
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "Has the figure."},
+                {"chunk_index": 1, "needed": "needed", "reason": "Adds the growth rate."},
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Revenue was $10M.",
+        input="What was the revenue and its growth?",
+        context="Revenue was $10M --- Revenue grew 12% YoY",
+    )
+
+    assert result.assessed
+    assert result.score == 1.0
+    assert result.passed
+    assert result.details["needed_chunks"] == 2
+    assert result.details["total_chunks"] == 2
+    assert len(result.details["chunk_verdicts"]) == 2
+
+
+def test_precision_redundant_chunk_reduces_score() -> None:
+    # Precision is a set-level measurement: an on-topic chunk that repeats
+    # information another retrieved chunk already supplies was not needed.
+    scorer = _precision_scorer(
+        {
+            "score": 2,
+            "explanation": "One chunk repeats the other.",
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "States the figure."},
+                {"chunk_index": 1, "needed": "not_needed", "reason": "Repeats the figure."},
+                {"chunk_index": 2, "needed": "not_needed", "reason": "Off topic."},
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Revenue was $10M.",
+        input="What was the revenue?",
+        context="Revenue was $10M --- Revenue was $10 million --- Weather forecast",
+    )
+
+    assert result.assessed
+    assert result.score == 1 / 3
+    assert not result.passed
+    assert result.details["needed_chunks"] == 1
+    assert result.details["total_chunks"] == 3
+
+
+def test_precision_no_chunks_needed_scores_zero() -> None:
+    scorer = _precision_scorer(
+        {
+            "score": 0,
+            "explanation": "Nothing was needed.",
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "not_needed", "reason": "Off topic."},
+                {"chunk_index": 1, "needed": "not_needed", "reason": "Off topic."},
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "What is the revenue?",
+        input="What is the revenue?",
+        context="Weather is sunny --- Sports scores",
+    )
+
+    assert result.assessed
+    assert result.score == 0.0
+    assert not result.passed
+    assert result.details["needed_chunks"] == 0
+    assert result.details["total_chunks"] == 2
+
+
+def test_precision_contradictory_judge_score_is_advisory() -> None:
+    # The judge claims a perfect score while marking every chunk not needed.
+    # The returned score follows the validated verdicts; the contradictory
+    # number stays in details for audit.
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "explanation": "Perfect retrieval.",
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "not_needed", "reason": "Off topic."},
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "What is the revenue?",
+        input="What is the revenue?",
+        context="Weather is sunny",
+    )
+
+    assert result.assessed
+    assert result.score == 0.0
+    assert result.details["judge_score"] == 3.0
+    assert "Perfect retrieval." not in result.explanation
+    assert result.details["judge_explanation"] == "Perfect retrieval."
+
+
+def test_precision_boolean_judge_score_is_rejected_not_coerced() -> None:
+    scorer = _precision_scorer(
+        {
+            "score": True,
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "Has the figure."},
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Revenue was $10M.",
+        input="What is the revenue?",
+        context="[doc-1] Revenue was $10 million.",
+    )
+
+    assert result.assessed
+    assert result.details["judge_score"] is None
+
+
+def test_precision_native_labelled_blocks_are_chunks() -> None:
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "Has the figure."},
+                {"chunk_index": 1, "needed": "not_needed", "reason": "Off topic."},
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Revenue was $10M.",
+        input="What was the revenue?",
+        context="[doc-1] Revenue was $10 million\n\n[doc-2] Weather was sunny",
+    )
+
+    assert result.assessed
+    assert result.details["total_chunks"] == 2
+    assert result.score == 0.5
+
+
+def test_precision_prompt_uses_envelopes_not_delimiters() -> None:
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "Has the figure."},
+                {"chunk_index": 1, "needed": "needed", "reason": "Adds context."},
+            ],
+        }
+    )
+
+    scorer.score(
+        "Revenue was $10M.",
+        input="What was the revenue?",
+        context="[doc-1] Revenue was $10M --- audited figure\n\n[doc-2] Weather only",
+    )
+
+    judge_prompt = scorer._call_judge.call_args[0][1]
+    # Count real envelope openings only: the template prose also mentions
+    # <chunk index="N"> with a literal N. The delimiter inside the labelled
+    # first chunk cannot read as a boundary, so it stays one envelope.
+    assert len(re.findall(r'<chunk index="\d+">', judge_prompt)) == 2
+    assert (
+        '<chunk index="0">\n[doc-1] Revenue was $10M --- audited figure\n</chunk>'
+        in judge_prompt
+    )
+
+
+# --------------------------------------------------------------------------
+# ContextPrecisionScorer: parse failures and discards
+# --------------------------------------------------------------------------
+
+
+def test_precision_missing_chunk_verdicts_are_a_parse_failure() -> None:
+    scorer = _precision_scorer({"score": 0, "chunk_verdicts": []})
+
+    result = scorer.score(
+        "What is the revenue?",
+        input="What is the revenue?",
+        context="Some context",
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert result.details["total_chunks"] == 1
+    assert result.details["covered_chunks"] == 0
+    assert result.details["missing_chunk_indexes"] == [0]
+    assert "judge_response" in result.details
+
+
+def test_precision_partial_verdict_coverage_is_a_parse_failure() -> None:
+    scorer = _precision_scorer(
+        {
+            "score": 2,
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "Has the figure."},
+                {"chunk_index": 1, "needed": "not_needed", "reason": "Off topic."},
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "What is the revenue?",
+        input="What is the revenue?",
+        context="Revenue was $10M --- Weather forecast --- Tax rate info",
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert result.details["missing_chunk_indexes"] == [2]
+    assert result.details["discarded_verdicts"] == 0
+
+
+def test_precision_duplicate_chunk_indexes_are_a_parse_failure() -> None:
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "First verdict."},
+                {"chunk_index": 0, "needed": "not_needed", "reason": "Duplicate."},
+                {"chunk_index": 1, "needed": "needed", "reason": "On topic."},
+            ],
+        }
+    )
+
+    result = scorer.score("Answer", input="Question", context="Chunk A --- Chunk B")
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert result.details["duplicate_chunk_indexes"] == [0]
+    assert result.details["discarded_verdicts"] == 1
+
+
+def test_precision_out_of_range_indexes_are_a_parse_failure() -> None:
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "On topic."},
+                {"chunk_index": 7, "needed": "needed", "reason": "Invented chunk."},
+            ],
+        }
+    )
+
+    result = scorer.score("Answer", input="Question", context="Chunk A --- Chunk B")
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert result.details["total_chunks"] == 2
+    assert result.details["out_of_range_chunk_indexes"] == [7]
+
+
+def test_precision_unknown_label_is_a_parse_failure() -> None:
+    # The label is unrecognized, so the verdict is discarded and the chunk it
+    # claimed is left without one: that is a parse failure, not a silent pass.
+    scorer = _precision_scorer(
+        {
+            "score": 2,
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "kinda needed", "reason": "Off-scale label."},
+            ],
+        }
+    )
+
+    result = scorer.score("Answer", input="Question", context="Chunk A")
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert result.details["discarded_verdicts"] == 1
+    assert result.details["missing_chunk_indexes"] == [0]
+
+
+def test_precision_non_dict_verdicts_are_discarded() -> None:
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "chunk_verdicts": [
+                "needed",
+                42,
+                {"chunk_index": 0, "needed": "needed", "reason": "On topic."},
+            ],
+        }
+    )
+
+    result = scorer.score("Answer", input="Question", context="Chunk A")
+
+    assert result.assessed
+    assert result.details["needed_chunks"] == 1
+    assert result.details["discarded_verdicts"] == 2
+
+
+def test_precision_non_integer_chunk_indexes_are_discarded_not_coerced() -> None:
+    # Bools, floats, and numeric strings are not chunk indexes: float(True)
+    # is 1.0 and int("0") is 0, so coercing any of them would let a malformed
+    # verdict grade a real chunk.
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "chunk_verdicts": [
+                {"chunk_index": True, "needed": "needed", "reason": "Bool index."},
+                {"chunk_index": 0.0, "needed": "needed", "reason": "Float index."},
+                {"chunk_index": "1", "needed": "needed", "reason": "String index."},
+                {"chunk_index": 0, "needed": "needed", "reason": "Real verdict."},
+            ],
+        }
+    )
+
+    result = scorer.score("Answer", input="Question", context="Chunk A")
+
+    assert result.assessed
+    assert result.details["needed_chunks"] == 1
+    assert result.details["discarded_verdicts"] == 3
+
+
+def test_precision_non_object_json_reply_is_controlled_unassessed() -> None:
+    for bad_reply in (None, [1, 2], "cannot grade", 7):
+        scorer = _precision_scorer(bad_reply)
+
+        result = scorer.score(
+            "What is the revenue?",
+            input="What is the revenue?",
+            context="[doc-1] Revenue was $10 million.",
+        )
+
+        assert not result.assessed, bad_reply
+        assert result.details["skipped"] == "judge_parse_failure", bad_reply
+        assert result.details["judge_response"] == bad_reply, bad_reply
+
+
+def test_precision_parse_failure_reply_is_strict_json_serializable() -> None:
+    bad_reply = {
+        "score": float("nan"),
+        "explanation": "garbage",
+        "chunk_verdicts": [
+            {"chunk_index": float("inf"), "needed": "needed"},
+        ],
+    }
+    scorer = _precision_scorer(bad_reply)
+
+    result = scorer.score(
+        "What is the revenue?",
+        input="What is the revenue?",
+        context="[doc-1] Revenue was $10 million.\n[doc-2] Weather only",
+    )
+
+    assert not result.assessed
+    stored = result.details["judge_response"]
+    assert stored["score"] == "NaN"
+    assert stored["chunk_verdicts"][0]["chunk_index"] == "Infinity"
+    json.dumps(result.details, allow_nan=False)
+
+
+# --------------------------------------------------------------------------
+# ContextRecallScorer: skip paths
+# --------------------------------------------------------------------------
+
+
+def test_recall_missing_context_is_unassessed_without_calling_judge() -> None:
+    scorer = _recall_scorer({"score": 3})
+
+    result = scorer.score("A response", input="Q", context="  ", expected="A reference.")
+
+    assert not result.assessed
+    assert result.details["skipped"] == "empty_context"
+    scorer._call_judge.assert_not_called()
+
+
+def test_recall_blank_query_is_unassessed_without_calling_judge() -> None:
+    scorer = _recall_scorer({"score": 3})
+
+    result = scorer.score(
+        "A response", input="   ", context="Chunk A --- Chunk B", expected="A reference."
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "empty_query"
+    scorer._call_judge.assert_not_called()
+
+
+def test_recall_missing_reference_is_unassessed_without_calling_judge() -> None:
+    # Recall needs a reference to measure against: without one the row is a
+    # coverage gap, not a zero.
+    scorer = _recall_scorer({"score": 3})
+
+    result = scorer.score(
+        "A response", input="What is the revenue?", context="Chunk A --- Chunk B"
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "missing_reference"
+    scorer._call_judge.assert_not_called()
+
+
+def test_recall_blank_reference_is_unassessed_without_calling_judge() -> None:
+    scorer = _recall_scorer({"score": 3})
+
+    result = scorer.score(
+        "A response",
+        input="What is the revenue?",
+        context="Chunk A --- Chunk B",
+        expected="   ",
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "missing_reference"
+    scorer._call_judge.assert_not_called()
+
+
+def test_recall_refusal_shaped_expected_is_still_assessed() -> None:
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "Refuse to reveal private account data.",
+                    "supported": True,
+                    "context_span": "Account data is restricted.",
+                    "reason": "States the restriction.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "I can't provide private account data.",
+        input="Show me private account data",
+        context="[doc-1] Account data is restricted.",
+        expected="Refuse to reveal private account data.",
+    )
+
+    assert result.assessed
+    scorer._call_judge.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# ContextRecallScorer: scoring
+# --------------------------------------------------------------------------
+
+
+def test_recall_all_items_supported_scores_one() -> None:
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "explanation": "Everything was retrieved.",
+            "reference_items": [
+                {
+                    "reference_span": "Revenue was $10 million.",
+                    "supported": True,
+                    "context_span": "Revenue was $10 million.",
+                    "reason": "Stated verbatim.",
+                },
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": True,
+                    "context_span": "Growth was 12%.",
+                    "reason": "Stated verbatim.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Revenue was $10 million and grew 12%.",
+        input="What was the revenue and growth?",
+        context="[doc-1] Revenue was $10 million.\n\n[doc-2] Growth was 12%.",
+        expected="Revenue was $10 million. Growth was 12%.",
+    )
+
+    assert result.assessed
+    assert result.score == 1.0
+    assert result.passed
+    assert result.details["supported_items"] == 2
+    assert result.details["total_items"] == 2
+
+
+def test_recall_missing_item_reduces_score() -> None:
+    scorer = _recall_scorer(
+        {
+            "score": 2,
+            "explanation": "Growth was not retrieved.",
+            "reference_items": [
+                {
+                    "reference_span": "Revenue was $10 million.",
+                    "supported": True,
+                    "context_span": "Revenue was $10 million.",
+                    "reason": "Stated verbatim.",
+                },
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Not in the retrieved chunks.",
+                },
+                {
+                    "reference_span": "The quarter ended in June.",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Not in the retrieved chunks.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Revenue was $10 million.",
+        input="Summarize the quarter.",
+        context="[doc-1] Revenue was $10 million.",
+        expected="Revenue was $10 million. Growth was 12%. The quarter ended in June.",
+    )
+
+    assert result.assessed
+    assert result.score == 1 / 3
+    assert not result.passed
+    assert result.details["supported_items"] == 1
+    assert result.details["total_items"] == 3
+
+
+def test_recall_no_items_supported_scores_zero() -> None:
+    scorer = _recall_scorer(
+        {
+            "score": 0,
+            "reference_items": [
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Not retrieved.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Nothing useful.",
+        input="What was the growth?",
+        context="[doc-1] Weather was sunny.",
+        expected="Growth was 12%.",
+    )
+
+    assert result.assessed
+    assert result.score == 0.0
+    assert not result.passed
+
+
+def test_recall_contradictory_judge_score_is_advisory() -> None:
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "explanation": "Everything was retrieved.",
+            "reference_items": [
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Not retrieved.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Nothing useful.",
+        input="What was the growth?",
+        context="[doc-1] Weather was sunny.",
+        expected="Growth was 12%.",
+    )
+
+    assert result.assessed
+    assert result.score == 0.0
+    assert result.details["judge_score"] == 3.0
+    assert "Everything was retrieved." not in result.explanation
+    assert result.details["judge_explanation"] == "Everything was retrieved."
+
+
+def test_recall_boolean_judge_score_is_rejected_not_coerced() -> None:
+    scorer = _recall_scorer(
+        {
+            "score": False,
+            "reference_items": [
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": True,
+                    "context_span": "Growth was 12%.",
+                    "reason": "Stated verbatim.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert result.assessed
+    assert result.details["judge_score"] is None
+
+
+# --------------------------------------------------------------------------
+# ContextRecallScorer: anchor validation
+# --------------------------------------------------------------------------
+
+
+def test_recall_fabricated_reference_span_is_discarded() -> None:
+    # A judge that lists a piece of information the reference does not contain
+    # must not inflate the denominator: the span is not verbatim, so the item
+    # is discarded and the surviving item alone is scored.
+    scorer = _recall_scorer(
+        {
+            "score": 1,
+            "reference_items": [
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": True,
+                    "context_span": "Growth was 12%.",
+                    "reason": "Stated verbatim.",
+                },
+                {
+                    "reference_span": "Profit doubled.",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Invented piece.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert result.assessed
+    assert result.details["discarded_items"] == 1
+    assert result.details["total_items"] == 1
+    assert result.score == 1.0
+
+
+def test_recall_all_items_discarded_is_a_parse_failure() -> None:
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "Profit doubled.",
+                    "supported": True,
+                    "context_span": "Profit doubled.",
+                    "reason": "Invented piece.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert result.details["discarded_items"] == 1
+    assert "judge_response" in result.details
+
+
+def test_recall_empty_item_list_is_a_parse_failure() -> None:
+    scorer = _recall_scorer({"score": 3, "reference_items": []})
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+
+
+def test_recall_unverifiable_context_span_downgrades_to_not_supported() -> None:
+    # The judge claims the piece is supported but quotes context text that is
+    # not in the retrieved chunks. The support claim cannot be verified, so
+    # the piece counts as not supported rather than being trusted.
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": True,
+                    "context_span": "Growth was 99%.",
+                    "reason": "Paraphrased or invented.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert result.assessed
+    assert result.score == 0.0
+    assert result.details["unverified_support_items"] == 1
+    assert result.details["supported_items"] == 0
+    assert result.details["reference_items"][0]["supported"] is False
+
+
+def test_recall_context_span_is_checked_against_the_rendered_chunks() -> None:
+    # The judge reads the XML-escaped chunk envelopes, so a chunk containing
+    # "&" is shown as "&amp;". A context span quoted from that view verifies;
+    # the raw form is not what the judge was shown and does not.
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "R&D spending was $2M.",
+                    "supported": True,
+                    "context_span": "R&amp;D spending was $2M",
+                    "reason": "Quoted from the envelope.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "R&D spending was $2M.",
+        input="What was R&D spending?",
+        context="[doc-1] R&D spending was $2M",
+        expected="R&D spending was $2M.",
+    )
+
+    assert result.assessed
+    assert result.score == 1.0
+    assert result.details["reference_items"][0]["context_span"] == "R&amp;D spending was $2M"
+
+
+def test_recall_duplicate_reference_span_is_a_parse_failure() -> None:
+    # The same piece listed twice would double-count in the denominator, so
+    # the item set is ambiguous and the row is un-assessed.
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": True,
+                    "context_span": "Growth was 12%.",
+                    "reason": "First listing.",
+                },
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": False,
+                    "context_span": "",
+                    "reason": "Duplicate listing.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert result.details["duplicate_reference_spans"] == ["Growth was 12%."]
+
+
+def test_recall_non_boolean_supported_flag_is_discarded() -> None:
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": "yes",
+                    "context_span": "Growth was 12%.",
+                    "reason": "String flag.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert not result.assessed
+    assert result.details["skipped"] == "judge_parse_failure"
+    assert result.details["discarded_items"] == 1
+
+
+def test_recall_non_dict_items_are_discarded() -> None:
+    scorer = _recall_scorer(
+        {
+            "score": 3,
+            "reference_items": [
+                "Growth was 12%.",
+                42,
+                {
+                    "reference_span": "Growth was 12%.",
+                    "supported": True,
+                    "context_span": "Growth was 12%.",
+                    "reason": "Real item.",
+                },
+            ],
+        }
+    )
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert result.assessed
+    assert result.details["discarded_items"] == 2
+    assert result.details["total_items"] == 1
+
+
+def test_recall_non_object_json_reply_is_controlled_unassessed() -> None:
+    for bad_reply in (None, [1, 2], "cannot grade", 7):
+        scorer = _recall_scorer(bad_reply)
+
+        result = scorer.score(
+            "Growth was 12%.",
+            input="What was the growth?",
+            context="[doc-1] Growth was 12%.",
+            expected="Growth was 12%.",
+        )
+
+        assert not result.assessed, bad_reply
+        assert result.details["skipped"] == "judge_parse_failure", bad_reply
+        assert result.details["judge_response"] == bad_reply, bad_reply
+
+
+def test_recall_parse_failure_reply_is_strict_json_serializable() -> None:
+    bad_reply = {
+        "score": float("nan"),
+        "explanation": "garbage",
+        "reference_items": [
+            {"reference_span": float("inf"), "supported": True},
+        ],
+    }
+    scorer = _recall_scorer(bad_reply)
+
+    result = scorer.score(
+        "Growth was 12%.",
+        input="What was the growth?",
+        context="[doc-1] Growth was 12%.",
+        expected="Growth was 12%.",
+    )
+
+    assert not result.assessed
+    stored = result.details["judge_response"]
+    assert stored["score"] == "NaN"
+    assert stored["reference_items"][0]["reference_span"] == "Infinity"
+    json.dumps(result.details, allow_nan=False)
+
+
+# --------------------------------------------------------------------------
+# Prompt templates
+# --------------------------------------------------------------------------
+
+
+def test_precision_template_json_example_is_parseable() -> None:
+    template = JUDGE_PROMPTS["ContextPrecisionScorer"]["template"]
+    rendered = template.format(output="o", input="i", context="c")
+    block = rendered.split("Respond in JSON format:", 1)[1]
+
+    json_like = (
+        block.replace("<0-3>", "2")
+        .replace("<brief reasoning about how much of the retrieved set was needed>", "ok")
+        .replace("needed|not_needed", "needed")
+        .replace("<one short sentence>", "because")
+        .replace("...", "")
+    )
+    json_like = re.sub(r",(\s*\])", r"\1", json_like)
+
+    payload = json.loads(json_like)
+    assert payload["score"] == 2
+    assert payload["chunk_verdicts"][0]["chunk_index"] == 0
+    assert payload["chunk_verdicts"][0]["needed"] == "needed"
+
+
+def test_recall_template_json_example_is_parseable() -> None:
+    template = JUDGE_PROMPTS["ContextRecallScorer"]["template"]
+    rendered = template.format(input="i", context="c", expected="e")
+    block = rendered.split("Respond in JSON format:", 1)[1]
+
+    json_like = (
+        block.replace("<0-3>", "2")
+        .replace("<brief reasoning about what was and was not retrieved>", "ok")
+        .replace("<exact text copied from the Reference Answer>", "ref")
+        .replace("<exact text copied from the Retrieved Context>", "ctx")
+        .replace("<one short sentence>", "because")
+        .replace("...", "")
+    )
+    json_like = re.sub(r",(\s*\])", r"\1", json_like)
+
+    payload = json.loads(json_like)
+    assert payload["score"] == 2
+    assert payload["reference_items"][0]["reference_span"] == "ref"
+    assert payload["reference_items"][0]["supported"] is True
+    assert payload["reference_items"][0]["context_span"] == "ctx"

--- a/tests/test_context_precision_recall.py
+++ b/tests/test_context_precision_recall.py
@@ -210,6 +210,79 @@ def test_precision_identical_chunks_both_needed_are_demoted() -> None:
     ]
 
 
+def test_precision_duplicate_grouping_ignores_source_labels() -> None:
+    # The same passage retrieved under two source IDs is the same information
+    # twice: grouping must strip the leading [source-id] label, so both
+    # copies marked needed are corrected instead of scoring perfect precision.
+    scorer = _precision_scorer(
+        {
+            "score": 3,
+            "explanation": "Both chunks state the figure.",
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "needed", "reason": "States the figure."},
+                {"chunk_index": 1, "needed": "needed", "reason": "Also states it."},
+            ],
+        }
+    )
+
+    scorer.threshold = 0.7
+    result = scorer.score(
+        "Revenue was $10M.",
+        input="What was the revenue?",
+        context="[doc-1] Revenue was $10M.\n\n[doc-2] Revenue was $10M.",
+    )
+
+    assert result.assessed
+    assert result.score == 0.5
+    assert result.details["needed_chunks"] == 1
+    assert result.details["chunk_verdicts"][0]["needed"] == "needed"
+    assert result.details["chunk_verdicts"][1]["needed"] == "not_needed"
+    assert result.details["duplicate_chunk_corrections"] == [
+        {
+            "chunk_index": 1,
+            "duplicate_of": 0,
+            "reason": (
+                "Exact duplicate of chunk 0; the lowest-index chunk "
+                "supplies the information."
+            ),
+        }
+    ]
+
+
+def test_precision_lowest_index_rule_is_enforced_both_ways() -> None:
+    # The judge contradicts the lowest-index rule: the first copy is marked
+    # not_needed while the second is marked needed. Resolving the group to
+    # the documented rule -- the lowest-index copy supplies the information
+    # -- scores 0.5; demoting only the second copy would zero the score.
+    scorer = _precision_scorer(
+        {
+            "score": 1,
+            "explanation": "The duplicate is redundant.",
+            "chunk_verdicts": [
+                {"chunk_index": 0, "needed": "not_needed", "reason": "Redundant."},
+                {"chunk_index": 1, "needed": "needed", "reason": "States the figure."},
+            ],
+        }
+    )
+
+    scorer.threshold = 0.7
+    result = scorer.score(
+        "Revenue was $10M.",
+        input="What was the revenue?",
+        context="Revenue was $10M --- Revenue was $10M",
+    )
+
+    assert result.assessed
+    assert result.score == 0.5
+    assert result.details["needed_chunks"] == 1
+    assert result.details["chunk_verdicts"][0]["needed"] == "needed"
+    assert result.details["chunk_verdicts"][1]["needed"] == "not_needed"
+    assert [
+        (correction["chunk_index"], correction["duplicate_of"])
+        for correction in result.details["duplicate_chunk_corrections"]
+    ] == [(0, 0), (1, 0)]
+
+
 def test_precision_no_chunks_needed_scores_zero() -> None:
     scorer = _precision_scorer(
         {
@@ -635,9 +708,10 @@ def test_recall_all_items_supported_scores_one() -> None:
     assert result.assessed
     assert result.score == 1.0
     assert result.passed
-    # Adjacent supported pieces merge into one supplied region.
-    assert result.details["supported_regions"] == 1
-    assert result.details["total_regions"] == 1
+    # Both supplied sentences merge into one supported stretch covering the
+    # whole 40-character reference.
+    assert result.details["supported_span_length"] == 40
+    assert result.details["total_span_length"] == 40
 
 
 def test_recall_missing_item_reduces_score() -> None:
@@ -677,13 +751,14 @@ def test_recall_missing_item_reduces_score() -> None:
     )
 
     assert result.assessed
-    assert result.score == 1 / 2
+    assert result.score == 24 / 66
     assert not result.passed
-    # The two unsupported sentences are adjacent, so they merge into one
-    # unsupplied region: the judge could equally have listed them as a single
-    # piece, and the score must not depend on that choice.
-    assert result.details["supported_regions"] == 1
-    assert result.details["total_regions"] == 2
+    # The two unsupported sentences merge into one unsupplied stretch: the
+    # judge could equally have listed them as a single piece, and the score
+    # must not depend on that choice. The supplied sentence is weighed by
+    # its 24 characters against the 66 the pieces cover.
+    assert result.details["supported_span_length"] == 24
+    assert result.details["total_span_length"] == 66
 
 
 def test_recall_score_is_invariant_to_equivalent_splits() -> None:
@@ -758,9 +833,12 @@ def test_recall_score_is_invariant_to_equivalent_splits() -> None:
 
     assert sentence_level.assessed
     assert word_level.assessed
-    assert sentence_level.score == word_level.score == 0.5
-    assert sentence_level.details["total_regions"] == 2
-    assert word_level.details["total_regions"] == 2
+    # 17 of the 31 covered reference characters are supplied: the word-level
+    # split merges back into the same supported stretch, so both replies
+    # weigh the same supplied length against the same total.
+    assert sentence_level.score == word_level.score == 17 / 31
+    assert sentence_level.details["total_span_length"] == 31
+    assert word_level.details["total_span_length"] == 31
 
 
 def test_recall_no_items_supported_scores_zero() -> None:
@@ -884,7 +962,7 @@ def test_recall_fabricated_reference_span_is_discarded() -> None:
 
     assert result.assessed
     assert result.details["discarded_items"] == 1
-    assert result.details["total_regions"] == 1
+    assert result.details["total_span_length"] == 15
     assert result.score == 1.0
 
 
@@ -958,7 +1036,7 @@ def test_recall_unverifiable_context_span_downgrades_to_not_supported() -> None:
     assert result.assessed
     assert result.score == 0.0
     assert result.details["unverified_support_items"] == 1
-    assert result.details["supported_regions"] == 0
+    assert result.details["supported_span_length"] == 0
     assert result.details["reference_items"][0]["supported"] is False
 
 
@@ -1222,8 +1300,52 @@ def test_recall_repeated_sentence_scored_per_occurrence() -> None:
 
     assert result.assessed
     assert result.score == 0.5
-    assert result.details["supported_regions"] == 1
-    assert result.details["total_regions"] == 2
+    assert result.details["supported_span_length"] == 12
+    assert result.details["total_span_length"] == 24
+
+
+def test_recall_falls_as_missing_facts_grow() -> None:
+    # One supplied fact followed by one, three, and ten distinct unsupported
+    # facts: the score must fall as the unsupplied information grows. A count
+    # of same-verdict runs would return 0.5 for every one of these rows.
+    missing_facts = [f"Unrelated fact {number}." for number in range(1, 11)]
+    scores: list[float] = []
+    for count in (1, 3, 10):
+        scorer = _recall_scorer(
+            {
+                "score": 2,
+                "explanation": "Only the revenue was retrieved.",
+                "reference_items": [
+                    {
+                        "reference_span": "Revenue was $10 million.",
+                        "supported": True,
+                        "context_span": "Revenue was $10 million.",
+                        "reason": "Supplied verbatim.",
+                    },
+                    *(
+                        {
+                            "reference_span": fact,
+                            "supported": False,
+                            "context_span": "",
+                            "reason": "Not in the retrieved chunks.",
+                        }
+                        for fact in missing_facts[:count]
+                    ),
+                ],
+            }
+        )
+
+        result = scorer.score(
+            "Revenue was $10 million.",
+            input="What was the revenue?",
+            context="[doc-1] Revenue was $10 million.",
+            expected="Revenue was $10 million. " + " ".join(missing_facts[:count]),
+        )
+
+        assert result.assessed
+        scores.append(result.score)
+
+    assert scores[0] > scores[1] > scores[2]
 
 
 def test_recall_omitted_fact_is_a_parse_failure() -> None:
@@ -1380,7 +1502,7 @@ def test_recall_non_dict_items_are_discarded() -> None:
 
     assert result.assessed
     assert result.details["discarded_items"] == 2
-    assert result.details["total_regions"] == 1
+    assert result.details["total_span_length"] == 15
 
 
 def test_recall_non_object_json_reply_is_controlled_unassessed() -> None:


### PR DESCRIPTION
Closes #26.

Adds two set-level retrieval-quality scorers that grade the retrieved set as a whole, complementing `RetrievalRelevanceScorer` (#37), which grades each chunk on its own.

## What's added

- **`ContextPrecisionScorer`** — of the chunks that were retrieved, how many were actually needed to answer the query. A chunk that repeats information another retrieved chunk already supplies is `not_needed`, so padding and redundancy count against the score. The prompt's tie-break for identical chunks (lowest index is the needed one) is enforced by the scorer itself: chunks are grouped by passage content without the leading `[source-id]` label, so the same passage under two source IDs still groups as a duplicate, and within a group with any `needed` copy the lowest-index copy is the needed one — later copies marked `needed` are demoted and a lowest-index copy marked `not_needed` is promoted — with every correction recorded in `details["duplicate_chunk_corrections"]`.
- **`ContextRecallScorer`** — of the information needed to answer the query, how much the retrieval actually supplied. The judge decomposes the row's reference answer into individual pieces, each anchored to a verbatim span of the reference, and marks each with a JSON Boolean `supported` field plus a verbatim context span as evidence.

## Conventions followed

- Reuses the collision-safe chunk parsing (`_split_context_chunks`) and numbered envelope rendering (`_render_context_chunks`) that landed with #37; no second parser and no incompatible chunk format.
- Rows with no retrieved context return `assessed=False` (`skipped="empty_context"`) rather than a defaulted zero.
- Recall needs a reference: rows without `expected` return `assessed=False` with `skipped="missing_reference"`.
- Neither scorer skips refusal-shaped rows. These scorers grade the retriever, so retrieved context stays gradable when the generator declines to answer.
- Both derive their score from validated verdicts rather than the judge's own number; the judge's score is kept as an advisory value in `details["judge_score"]`.
- Recall anchors both sides: a piece whose reference span is not verbatim in `expected` is discarded, so a judge cannot invent information the reference does not contain; a `supported` piece whose context span is not verbatim is downgraded to not supported, so a judge cannot assert support it cannot show.
- Recall binds each piece to exactly one occurrence of its reference span: the earliest occurrence no earlier piece has claimed. A span the reference repeats must be listed once per occurrence, so one piece can never cover every repeated occurrence; a listing with no unclaimed occurrence left fails the parse rather than double-counting. The surviving pieces must also form a complete, non-overlapping decomposition of the reference (omitted pieces or overlapping spans fail the parse), so a judge cannot shrink the denominator.
- Recall scores the reference text the retrieval supplied, not judge items: adjacent pieces sharing a verdict are merged into maximal stretches of the reference, and the score is supported stretch length over total stretch length on the whitespace-collapsed reference — equivalent splits and merges leave the stretches unchanged, so the score does not depend on how the judge partitioned the same claims, while every additional unsupplied fact adds length the retrieval did not supply (`details["supported_span_length"]` / `details["total_span_length"]`).
- Context spans are verified against the original chunk content, not the XML-escaped envelope view: the judge's quote is unescaped, matched back to a retrieved chunk, and the stored span is the original chunk text, so a chunk containing `&` / `<` / `>` still verifies. The scaffolding check only strips real envelope markers and the matched chunk's own leading `[source-id]` label, so bracketed content such as `[FDA]` still verifies as evidence.
- Untrustworthy replies (non-object JSON, missing / duplicate / out-of-range verdicts, no verifiable reference piece, incomplete decomposition) return `assessed=False` with `skipped="judge_parse_failure"` instead of scoring.

## Out of scope

New `retrieved_ids` plumbing through `evaluation/pipeline.py` stays out of this PR, per the issue. If structured ID propagation proves necessary, it should be tracked in a separate focused issue.

## Tests

`tests/test_context_precision_recall.py` mocks `_call_judge`, so no key or network access is needed. On the branch: 164 passed, 4 skipped. Merged with current `main`: 208 passed, 4 skipped.

