### PR TITLE
feat: add model adapter contract docs and conformance suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,4 +88,5 @@ vulnerabilities.
 - Scoped starter work lives under the [good first issue](https://github.com/wandb/rai-toolkit/labels/good%20first%20issue) label.
 - Framework mappings (ISO/IEC 42001 #6, Colorado AI Act #7, NYC LL144 #8) mirror the existing NIST AI RMF mapping structure in `rai_toolkit/compliance/`.
 - The example policy pack under `rai_toolkit/policies/packs/example_enterprise_pack/` shows the policy format.
+- [`docs/model_adapters.md`](docs/model_adapters.md) is the contract every model adapter is held to — the `predict` signature, where retrieved context may and may not go, the standard metadata keys, lazy optional SDK imports, and `from_args`. Read it before adding or changing an adapter under `rai_toolkit/models/`, and add a `ModelAdapterContractTests` subclass (`tests/model_adapter_contract.py`) to the adapter's test module.
 - Lint policies with `rai policies lint`.

--- a/docs/model_adapters.md
+++ b/docs/model_adapters.md
@@ -1,0 +1,203 @@
+# Model adapters
+
+A model adapter is the seam between the toolkit and whatever system actually answers a prompt. Everything downstream — evaluation, red-teaming, guardrails, the assessment report — talks to a `BaseModel` and never to a provider SDK. That only holds if every adapter behaves the same way, so this page is the contract adapters are held to.
+
+The contract has an executable form: `tests/model_adapter_contract.py`. An adapter is not finished until it passes that suite.
+
+## When you need a dedicated adapter
+
+Start with `OpenAICompatibleModel`. It speaks the OpenAI chat-completions protocol, which is what the public OpenAI API, Azure, vLLM, Ollama, LiteLLM, and most internal proxies expose. Pointing it at a `base_url` costs nothing and adds no code to maintain.
+
+Write a dedicated adapter only when the provider's wire protocol genuinely differs and the difference is visible in the contract below. `AnthropicModel` exists because the Messages API carries system instructions in a top-level `system` parameter rather than a message, returns a list of content blocks rather than a single string, and names its token counts `input_tokens` / `output_tokens`. Each of those is a real translation, not a preference.
+
+Reasons that do **not** justify a new adapter: a different default model id, a different system prompt, a different temperature, or a convenience wrapper around one that already exists. Those are configuration.
+
+## Subclassing `BaseModel`
+
+```python
+from rai_toolkit.models.base import BaseModel, ModelResponse
+
+
+class MyProviderModel(BaseModel):
+    def __init__(self, model: str, api_key: str | None = None, name: str | None = None):
+        super().__init__(name=name or model)
+        self.model = model
+        self.api_key = api_key
+        self._client = None
+
+    async def predict(self, input_text, context="", **kwargs) -> ModelResponse:
+        ...
+```
+
+Call `super().__init__()` with the display name. `BaseModel` falls back to the class name when no name is given, which is rarely what a report reader wants to see; pass the model id instead.
+
+Do not decorate `predict` yourself. `BaseModel.__init_subclass__` wraps every subclass's `predict` with the toolkit's tracing op (see [Tracing](#tracing)).
+
+## The `predict` contract
+
+```python
+async def predict(self, input_text: str, context: str = "", **kwargs) -> ModelResponse
+```
+
+**`input_text` is the user's input and must not be silently rewritten.** Do not trim it, truncate it, prefix it, template it, or fold it into a longer instruction. Red-team and evaluation results are only meaningful if the string that was scored is the string that was sent. An adapter that needs standing instructions puts them in `system_prompt`, which is configuration the caller chose, not a rewrite of their input.
+
+With an empty `context` — the default — that means `input_text` is passed verbatim: it reaches the provider once, unchanged, as the user content string. When a caller supplies `context`, `input_text` is not altered either, but it is encapsulated as one field of the JSON user payload described in [Retrieved context](#retrieved-context); it round-trips out of that payload as the exact string the caller passed.
+
+**A non-empty `context` reaches the provider exactly once**, and never through a privileged channel. RAG evaluation depends on the retrieved passage actually being in the request; groundedness scoring depends on it being there once, not duplicated across a system block and a user turn. See below for where it goes.
+
+**An empty `context` must not create a synthetic context block.** `context=""` is the default and means "no retrieval happened". Emitting an empty `retrieved_context` field, or an empty "Retrieved context:" block, tells the model a retrieval returned nothing, which is a different claim from not having retrieved at all, and it changes behaviour.
+
+**`**kwargs` carries per-call overrides** of the adapter's own configured defaults (`temperature`, `max_tokens`, and the like). Validate them with the same rules the constructor uses, and reject bad values rather than passing them through to the provider.
+
+`predict` returns a `ModelResponse`, never a bare string, `None`, or a provider object.
+
+## Retrieved context
+
+Retrieved context is attacker-reachable data. A retrieval index can be poisoned, a scraped page can carry "ignore your instructions", and a red-team run exists precisely to send such passages. So context never enters the system prompt, the Anthropic top-level `system` parameter, or any other channel the model is entitled to read as instructions. It travels in the user turn, structurally separated from the caller's own input.
+
+**When `context` is non-empty**, the user message is a JSON object with exactly two keys:
+
+```json
+{"retrieved_context": "<the passage the retriever returned>", "input_text": "<the caller's input>"}
+```
+
+Both values round-trip: JSON encoding keeps quotes, braces, and newlines inside the retrieved passage from running together with the caller's input, so a scorer reading the request back gets the same two strings the caller passed.
+
+**When context is present, a fixed context handling policy is appended to the system instructions.** `rai_toolkit/models/_prompting.build_prompt_parts` owns both halves — it builds the JSON payload and appends the policy — so every built-in adapter states the same thing. The policy names the two fields, marks `retrieved_context` as untrusted reference data rather than instructions, and tells the model to answer `input_text`. It is appended to the caller's `system_prompt` when there is one and used on its own when there is not. Adapters do not reword it; a per-adapter variant would mean two adapters answering the same poisoned passage differently.
+
+**When `context` is empty**, none of this applies: no JSON wrapper, no policy sentence, and the user content is the bare `input_text` string. A request built with `context=""` stays byte-identical to one built with the argument omitted.
+
+This structure is defense in depth, not a guarantee. It removes one specific and well-understood failure — retrieved text arriving in a privileged channel, or blurring into the user's own question across an ad-hoc `"Retrieved context:"` delimiter — and it gives the model a trusted statement about which field is which. It does not make prompt injection impossible: a model can still be talked into following instructions inside a JSON string value. Treat it as raising the cost of an injection, and keep the guardrail and red-team layers doing their own work rather than relying on adapter-level framing to stop attacks outright.
+
+## Output fidelity
+
+`ModelResponse.output` is the provider's text, in the order the provider returned it, and nothing else.
+
+- Concatenate multi-part responses with `"".join(...)`. Do not insert newlines, spaces, or separators the provider did not send — a scorer cannot tell an invented separator from model output.
+- Do not reorder, deduplicate, or filter text segments.
+- Drop non-text parts (tool-use blocks, thinking blocks) rather than stringifying them into `output`. If they matter, surface them under a provider-specific metadata key.
+- When the provider returns no text, `output` is `""`. Do not substitute a placeholder, an apology, or an error string.
+
+## Standard metadata keys
+
+Every adapter populates these six keys on `ModelResponse.metadata`:
+
+| Key | Meaning |
+| --- | --- |
+| `model` | The model identifier sent to the provider |
+| `base_url` | The endpoint override in use, or `None` for the provider default |
+| `finish_reason` | Why generation stopped, in the provider's own vocabulary |
+| `prompt_tokens` | Input tokens billed |
+| `completion_tokens` | Output tokens billed |
+| `total_tokens` | Sum of the two, or the provider's own total |
+
+The keys are always present. Populate a key when the provider supplies the value, and set it to `None` when it does not — an absent key and a `None` value mean different things to report rendering, and the toolkit relies on the second. Read them defensively (`getattr(usage, "prompt_tokens", None)`); providers omit usage on some responses.
+
+Do not rename these keys to match a provider's vocabulary. `AnthropicModel` maps `input_tokens` to `prompt_tokens` and `stop_reason` to `finish_reason` precisely so downstream code never learns which provider answered. `finish_reason` is the one value passed through unchanged, because it is descriptive rather than structural.
+
+Provider-specific additions are allowed alongside the standard keys as long as they are documented in the adapter's docstring and never replace a standard key.
+
+## Display name
+
+`name` is a stable, non-empty string used in reports and logs. Set it once at construction and never mutate it during a call — a name that changes mid-run breaks the grouping of results. Default it to the model id.
+
+## Credentials
+
+An API key never appears in `repr`, in `ModelResponse.metadata`, or in an error message the adapter raises. `BaseModel.__repr__` renders only the class name and display name, so the safe thing is to leave it alone; if an adapter overrides `__repr__`, it must not add credential fields.
+
+Storing the key as an instance attribute is fine — `AnthropicModel` does, because it creates its client lazily — but it stays out of anything user-visible. When an adapter raises a configuration error, name the field, not the value: `"api_key must not be empty"`, never the key itself.
+
+## Error handling
+
+**Transport and authentication failures propagate.** Do not catch a provider's timeout, rate-limit, or 401 and turn it into an empty `ModelResponse` or a generic exception. An evaluation that silently scores a swallowed error as a model answer is worse than one that fails. Retries, backoff, and universal error types are out of scope for adapters.
+
+**Invalid configuration is rejected early**, in the constructor or in `from_args`, with a message that names the offending field. `AnthropicModel._coerce_max_tokens` is the model to follow: it normalizes `None` and blank strings to the documented default and raises `ValueError` naming `max_tokens` for anything else. Failing at construction surfaces the problem before a run starts rather than partway through it.
+
+## Tracing
+
+`BaseModel.__init_subclass__` wraps each subclass's `predict` with `_tracing.traced(name="rai.model.predict", kind="llm")`. Every adapter therefore emits exactly one span, under one op name, with one flattened output shape — regardless of whether it was called from the eval pipeline, a chat probe, or a red-team run.
+
+Do not add a second wrapper. Decorating `predict` with `@_tracing.traced` yourself sets the `__rai_traced_op_name__` sentinel, which `__init_subclass__` honours by skipping its own wrap; that is the escape hatch for classes that genuinely need a different op name (`GuardedModel` uses `rai.guardrails.predict`), not something a provider adapter wants. A plain adapter should leave `predict` undecorated and let the base class do it.
+
+## Optional SDKs and lazy imports
+
+`import rai_toolkit` and `import rai_toolkit.models` must keep working in an environment that has none of the optional provider packages installed. That is a hard constraint: `rai_toolkit/models/__init__.py` imports every adapter, so a top-level `import some_sdk` in an adapter module would break the whole package for everyone.
+
+So:
+
+1. Declare the SDK in a named extra in `pyproject.toml` (`anthropic = ["anthropic>=0.40.0"]`).
+2. Import it inside the function or property that needs it, not at module scope.
+3. Catch `ImportError` and re-raise one that names the extra:
+
+```python
+_ANTHROPIC_IMPORT_ERROR = (
+    "The 'anthropic' package is required to use AnthropicModel. "
+    "Install it with: pip install -e '.[anthropic]'"
+)
+```
+
+The lazy-client property in `AnthropicModel` shows the shape: `_client` starts as `None`, the `client` property imports and constructs on first use, and the error a user without the extra sees tells them exactly what to install.
+
+`OpenAICompatibleModel` imports `openai` at module scope because `openai` is a core dependency, not an extra. That is the only reason it is allowed to.
+
+## `from_args()`
+
+Each adapter module exposes a `from_args(args: dict) -> Adapter` factory. It is what the Streamlit intake form under `demo/` uses, so it takes a flat dict of strings from a form or a config file rather than typed Python values.
+
+- **Required fields** are validated explicitly and raise with a message naming the field: `raise ValueError("AnthropicModel requires a 'model' argument")`.
+- **Missing or empty optional fields are unset**, not empty. Use `args.get("api_key") or None` so `""` from an untouched form field becomes `None` and the SDK's own environment-variable resolution still applies. An empty string passed through as a key produces a confusing auth failure at the first call instead of the intended default.
+- **Type normalization happens here**, not at the call site. Accept the string forms a form produces (`"0.35"`, `"4000"`) and convert them, rejecting values that are not valid with a clear error. Share the coercion helper with the constructor so both entry points enforce the same rule.
+- Document the accepted keys and their defaults in the factory's docstring.
+
+## The conformance suite
+
+`tests/model_adapter_contract.py` provides `ModelAdapterContractTests`, a base class covering everything above: inheritance, a non-empty stable name, `predict` being async and returning a `ModelResponse`, verbatim input, single-delivery context, context never reaching a privileged channel, the JSON shape of the user turn when context is present, empty-context neutrality, output fidelity, the standard metadata keys, single tracing, transport-error propagation, optional-import behaviour, and credential redaction.
+
+Two hooks let the channel assertions stay provider-neutral. `privileged_texts(call)` returns the trusted instruction text in a recorded request and `user_texts(call)` returns the user-turn bodies; the defaults read a top-level `system` parameter and message `role` fields, which covers both built-in adapters. Override them only for a provider that spells trusted instructions some other way.
+
+The suite is fully offline and provider-neutral. It never imports `openai` or `anthropic` and never inspects a provider request type; it walks the plain dicts the adapter handed its mocked transport. Keep it that way — an assertion that reaches into a provider's SDK objects stops being a shared contract.
+
+To exercise it, add a `Test`-prefixed subclass to the adapter's own test module and supply the factory:
+
+```python
+class TestMyProviderContract(ModelAdapterContractTests):
+    adapter_module = my_provider
+    optional_sdk_module = "my_sdk"
+    optional_sdk_extra = "[my-provider]"
+    secret_values = ("secret-test-key",)
+
+    def make_adapter(self):
+        return my_provider.MyProviderModel(model="m", api_key="secret-test-key")
+
+    def provider_calls(self, adapter):
+        return adapter.client.requests.calls
+
+    def set_transport_error(self, adapter, error):
+        async def failing_create(**kwargs):
+            raise error
+
+        adapter.client.requests.create = failing_create
+
+    def expected_output(self, adapter):
+        return "offline answer"
+```
+
+`make_adapter` returns a configured adapter whose transport is already mocked — the existing modules do this with an autouse fixture that patches the SDK client class. `provider_calls` returns the request payloads that mock recorded. `secret_values` lists the credentials the redaction tests search for. Leave `optional_sdk_module` unset for an adapter built on a core dependency; the optional-import tests skip themselves.
+
+Provider-specific behaviour — message ordering, block concatenation, per-call overrides, `from_args` normalization — stays in the adapter's own tests. The conformance suite covers what is shared, not what is particular.
+
+## Checklist
+
+- [ ] Subclasses `BaseModel`, calls `super().__init__(name=...)`
+- [ ] `predict` is async, returns `ModelResponse`, leaves `input_text` verbatim
+- [ ] Non-empty `context` sent once, in the JSON user payload, never in a privileged channel
+- [ ] Context handling policy appended to the system instructions when context is present
+- [ ] Empty `context` changes nothing; `input_text` sent as the bare user content
+- [ ] `output` preserves provider text and order, invents nothing
+- [ ] All six standard metadata keys present, `None` when unavailable
+- [ ] No credentials in `repr`, metadata, or raised errors
+- [ ] Transport failures propagate; invalid config rejected at construction
+- [ ] `predict` left undecorated so `BaseModel` traces it once
+- [ ] Optional SDK in a named extra, imported lazily, error names the extra
+- [ ] `from_args` validates required fields and normalizes empty optionals
+- [ ] `ModelAdapterContractTests` subclass added to the adapter's test module

--- a/docs/model_adapters.md
+++ b/docs/model_adapters.md
@@ -47,7 +47,9 @@ With an empty `context` — the default — that means `input_text` is passed ve
 
 **An empty `context` must not create a synthetic context block.** `context=""` is the default and means "no retrieval happened". Emitting an empty `retrieved_context` field, or an empty "Retrieved context:" block, tells the model a retrieval returned nothing, which is a different claim from not having retrieved at all, and it changes behaviour.
 
-**`**kwargs` carries per-call overrides** of the adapter's own configured defaults (`temperature`, `max_tokens`, and the like). Validate them with the same rules the constructor uses, and reject bad values rather than passing them through to the provider.
+**`**kwargs` carries per-call overrides** of the adapter's own configured defaults. Today each built-in adapter reads exactly one key and silently ignores every other: `OpenAICompatibleModel` reads `temperature`, and `AnthropicModel` reads `max_tokens`. Unrecognized keys are dropped rather than forwarded to the provider, so a misspelled override fails silently — check the adapter you are calling before relying on one.
+
+An adapter that does read a key validates it with the same rule its constructor uses: `AnthropicModel` runs a per-call `max_tokens` through `_coerce_max_tokens`, so an invalid value raises `ValueError` before the request is built. A general `**kwargs` API — an agreed set of overrides and rejection of unknown or invalid keys — is follow-up work tracked in [#63](https://github.com/wandb/rai-toolkit/issues/63). A new adapter should not invent its own until that lands.
 
 `predict` returns a `ModelResponse`, never a bare string, `None`, or a provider object.
 

--- a/tests/model_adapter_contract.py
+++ b/tests/model_adapter_contract.py
@@ -1,0 +1,371 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+"""Reusable conformance suite for :class:`~rai_toolkit.models.base.BaseModel`.
+
+Every model adapter in the toolkit owes callers the same behaviour,
+regardless of which provider sits behind it: user input that survives
+intact, context forwarded exactly once and never through a privileged
+message channel, provider text preserved, the standard metadata keys, one
+tracing op, propagated transport failures, and credentials that never
+surface in ``repr`` or metadata. The contract is written up in
+``docs/model_adapters.md``; this module is its executable form.
+
+Adapter test modules subclass :class:`ModelAdapterContractTests`, name the
+subclass ``Test...`` so pytest collects it, and supply a factory that
+builds a configured adapter whose transport is mocked. The suite stays
+provider-neutral: it never imports a provider SDK and never inspects
+provider request types. It only reads the plain dicts the adapter handed
+to its transport.
+
+Example::
+
+    class TestMyModelContract(ModelAdapterContractTests):
+        adapter_module = my_module
+        secret_values = ("secret-test-key",)
+
+        def make_adapter(self):
+            return my_module.MyModel(model="m", api_key="secret-test-key")
+
+        def provider_calls(self, adapter):
+            return adapter._client.calls
+
+        def set_transport_error(self, adapter, error):
+            ...
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import sys
+from collections.abc import Iterator
+from typing import Any, ClassVar
+
+import pytest
+
+from rai_toolkit.models.base import BaseModel, ModelResponse
+
+TRACING_OP_NAME = "rai.model.predict"
+
+STANDARD_METADATA_KEYS = (
+    "model",
+    "base_url",
+    "finish_reason",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+)
+
+INPUT_MARKER = "contract-input-6f1c2a"
+CONTEXT_MARKER = "contract-context-9d4b7e"
+
+#: Roles whose content the model is entitled to treat as trusted
+#: instructions. Retrieved context must never be routed through one of
+#: them, whatever the provider calls it.
+PRIVILEGED_ROLES = frozenset({"system", "developer", "tool"})
+
+#: Keys of the JSON object adapters send as the user turn when a caller
+#: supplies retrieved context.
+CONTEXT_PAYLOAD_KEYS = ("retrieved_context", "input_text")
+
+
+class ContractTransportError(RuntimeError):
+    """Stand-in for a provider transport or authentication failure."""
+
+
+def iter_strings(value: Any) -> Iterator[str]:
+    """Yield every string reachable inside a nested payload.
+
+    Adapters hand their transport plain dicts, lists, and strings. Walking
+    them keeps the assertions provider-neutral: the suite never has to know
+    whether a provider carries context in a message list, a top-level
+    field, or anywhere else.
+    """
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            yield from iter_strings(key)
+            yield from iter_strings(item)
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            yield from iter_strings(item)
+
+
+def count_occurrences(payload: Any, needle: str) -> int:
+    return sum(text.count(needle) for text in iter_strings(payload))
+
+
+def content_text(content: Any) -> str:
+    """Flatten a message body to the text a model would read.
+
+    Providers spell a message body either as a plain string or as a list
+    of typed blocks. Joining the strings out of either shape keeps the
+    privileged-channel assertions from needing to know which.
+    """
+    return "".join(iter_strings(content))
+
+
+class ModelAdapterContractTests:
+    """Shared behavioural assertions every adapter must satisfy.
+
+    Subclasses override :meth:`make_adapter`, :meth:`provider_calls`, and
+    :meth:`set_transport_error`, and set :attr:`secret_values`. Adapters
+    whose SDK ships in a named extra also set :attr:`adapter_module`,
+    :attr:`optional_sdk_module`, and :attr:`optional_sdk_extra`; the
+    optional-import tests skip themselves for adapters built on a core
+    dependency.
+    """
+
+    adapter_module: Any = None
+    optional_sdk_module: str | None = None
+    optional_sdk_extra: str | None = None
+    secret_values: tuple[str, ...] = ()
+    from_args_invalid_args: ClassVar[dict[str, Any]] = {}
+
+    def make_adapter(self) -> BaseModel:
+        """Return a configured adapter instance with a mocked transport."""
+        raise NotImplementedError
+
+    def provider_calls(self, adapter: BaseModel) -> list[dict[str, Any]]:
+        """Return the request payloads the adapter sent to its transport."""
+        raise NotImplementedError
+
+    def set_transport_error(self, adapter: BaseModel, error: Exception) -> None:
+        """Make the adapter's next transport call raise ``error``."""
+        raise NotImplementedError
+
+    def privileged_texts(self, call: dict[str, Any]) -> list[str]:
+        """Return the trusted instruction text in one recorded request.
+
+        The default covers the two shapes the built-in adapters use: a
+        top-level ``system`` parameter and messages carrying a privileged
+        role. An adapter whose provider spells trusted instructions some
+        other way overrides this so the channel still gets checked.
+        """
+        texts: list[str] = []
+        system = call.get("system")
+        if system is not None:
+            texts.append(content_text(system))
+        for message in call.get("messages") or []:
+            if not isinstance(message, dict):
+                continue
+            if message.get("role") in PRIVILEGED_ROLES:
+                texts.append(content_text(message.get("content")))
+        return texts
+
+    def user_texts(self, call: dict[str, Any]) -> list[str]:
+        """Return the user-turn bodies in one recorded request."""
+        return [
+            content_text(message.get("content"))
+            for message in call.get("messages") or []
+            if isinstance(message, dict) and message.get("role") == "user"
+        ]
+
+    @pytest.fixture
+    def adapter(self) -> BaseModel:
+        return self.make_adapter()
+
+    def test_adapter_subclasses_base_model(self, adapter: BaseModel) -> None:
+        assert isinstance(adapter, BaseModel)
+        assert issubclass(type(adapter), BaseModel)
+
+    def test_display_name_is_a_non_empty_string(self, adapter: BaseModel) -> None:
+        assert isinstance(adapter.name, str)
+        assert adapter.name.strip() != ""
+
+    async def test_display_name_is_stable_across_calls(
+        self, adapter: BaseModel
+    ) -> None:
+        before = adapter.name
+        await adapter.predict(INPUT_MARKER)
+
+        assert adapter.name == before
+
+    def test_predict_is_asynchronous(self, adapter: BaseModel) -> None:
+        assert inspect.iscoroutinefunction(type(adapter).predict)
+
+    async def test_predict_returns_a_model_response(
+        self, adapter: BaseModel
+    ) -> None:
+        response = await adapter.predict(INPUT_MARKER)
+
+        assert isinstance(response, ModelResponse)
+        assert isinstance(response.output, str)
+        assert isinstance(response.metadata, dict)
+
+    async def test_predict_sends_user_input_verbatim_exactly_once(
+        self, adapter: BaseModel
+    ) -> None:
+        """With no context, the input is the user turn, untouched."""
+        await adapter.predict(INPUT_MARKER)
+
+        (call,) = self.provider_calls(adapter)
+        assert count_occurrences(call, INPUT_MARKER) == 1
+
+    async def test_non_empty_context_reaches_the_provider_exactly_once(
+        self, adapter: BaseModel
+    ) -> None:
+        await adapter.predict(INPUT_MARKER, context=CONTEXT_MARKER)
+
+        (call,) = self.provider_calls(adapter)
+        assert count_occurrences(call, CONTEXT_MARKER) == 1
+        assert count_occurrences(call, INPUT_MARKER) == 1
+
+    async def test_context_never_reaches_a_privileged_channel(
+        self, adapter: BaseModel
+    ) -> None:
+        await adapter.predict(INPUT_MARKER, context=CONTEXT_MARKER)
+
+        (call,) = self.provider_calls(adapter)
+        for text in self.privileged_texts(call):
+            assert CONTEXT_MARKER not in text
+
+    async def test_context_is_carried_as_json_in_the_user_turn(
+        self, adapter: BaseModel
+    ) -> None:
+        await adapter.predict(INPUT_MARKER, context=CONTEXT_MARKER)
+
+        (call,) = self.provider_calls(adapter)
+        (user_text,) = self.user_texts(call)
+        payload = json.loads(user_text)
+
+        assert isinstance(payload, dict)
+        assert sorted(payload) == sorted(CONTEXT_PAYLOAD_KEYS)
+        assert payload["retrieved_context"] == CONTEXT_MARKER
+        assert payload["input_text"] == INPUT_MARKER
+
+    async def test_empty_context_sends_input_as_the_bare_user_content(
+        self, adapter: BaseModel
+    ) -> None:
+        await adapter.predict(INPUT_MARKER)
+
+        (call,) = self.provider_calls(adapter)
+        assert self.user_texts(call) == [INPUT_MARKER]
+
+    async def test_empty_context_adds_nothing_to_the_request(self) -> None:
+        omitted = self.make_adapter()
+        await omitted.predict(INPUT_MARKER)
+        (without_context,) = self.provider_calls(omitted)
+
+        explicit = self.make_adapter()
+        await explicit.predict(INPUT_MARKER, context="")
+        (with_empty_context,) = self.provider_calls(explicit)
+
+        assert with_empty_context == without_context
+        assert sorted(iter_strings(with_empty_context)) == sorted(
+            iter_strings(without_context)
+        )
+
+    async def test_output_preserves_provider_text(
+        self, adapter: BaseModel
+    ) -> None:
+        response = await adapter.predict(INPUT_MARKER)
+
+        assert response.output == self.expected_output(adapter)
+
+    def expected_output(self, adapter: BaseModel) -> str:
+        """The exact text the mocked transport is expected to return."""
+        raise NotImplementedError
+
+    async def test_metadata_exposes_every_standard_key(
+        self, adapter: BaseModel
+    ) -> None:
+        response = await adapter.predict(INPUT_MARKER)
+
+        missing = [
+            key for key in STANDARD_METADATA_KEYS if key not in response.metadata
+        ]
+        assert missing == []
+
+    async def test_metadata_reports_the_configured_model(
+        self, adapter: BaseModel
+    ) -> None:
+        response = await adapter.predict(INPUT_MARKER)
+
+        assert isinstance(response.metadata["model"], str)
+        assert response.metadata["model"] != ""
+
+    def test_predict_is_traced_once_under_the_canonical_op_name(
+        self, adapter: BaseModel
+    ) -> None:
+        predict = type(adapter).__dict__["predict"]
+
+        assert getattr(predict, "__rai_traced_op_name__", None) == TRACING_OP_NAME
+
+        inner = getattr(predict, "__wrapped__", None)
+        assert inner is not None
+        assert getattr(inner, "__rai_traced_op_name__", None) is None
+
+    async def test_transport_failures_propagate(self, adapter: BaseModel) -> None:
+        self.set_transport_error(adapter, ContractTransportError("upstream refused"))
+
+        with pytest.raises(ContractTransportError, match="upstream refused"):
+            await adapter.predict(INPUT_MARKER)
+
+    def test_repr_never_exposes_credentials(self, adapter: BaseModel) -> None:
+        rendered = repr(adapter)
+
+        assert type(adapter).__name__ in rendered
+        assert adapter.name in rendered
+        for secret in self.secret_values:
+            assert secret not in rendered
+
+    async def test_response_metadata_never_exposes_credentials(
+        self, adapter: BaseModel
+    ) -> None:
+        response = await adapter.predict(INPUT_MARKER)
+
+        rendered = list(iter_strings(response.metadata))
+        for secret in self.secret_values:
+            assert all(secret not in text for text in rendered)
+
+    async def test_transport_error_messages_never_gain_credentials(
+        self, adapter: BaseModel
+    ) -> None:
+        self.set_transport_error(adapter, ContractTransportError("upstream refused"))
+
+        with pytest.raises(ContractTransportError) as exc_info:
+            await adapter.predict(INPUT_MARKER)
+
+        for secret in self.secret_values:
+            assert secret not in str(exc_info.value)
+
+    def test_from_args_rejects_invalid_configuration_early(self) -> None:
+        if self.adapter_module is None:
+            pytest.skip("adapter module not supplied")
+
+        with pytest.raises((ValueError, KeyError, TypeError)):
+            self.adapter_module.from_args(dict(self.from_args_invalid_args))
+
+    def test_adapter_module_imports_without_the_optional_sdk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        if self.optional_sdk_module is None:
+            pytest.skip("adapter does not depend on an optional SDK")
+
+        monkeypatch.setitem(sys.modules, self.optional_sdk_module, None)
+        importlib.invalidate_caches()
+        reloaded = importlib.reload(self.adapter_module)
+
+        assert issubclass(reloaded.BaseModel, BaseModel)
+
+    async def test_missing_optional_sdk_names_the_install_extra(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        if self.optional_sdk_module is None:
+            pytest.skip("adapter does not depend on an optional SDK")
+
+        adapter = self.make_adapter()
+        monkeypatch.setitem(sys.modules, self.optional_sdk_module, None)
+
+        with pytest.raises(ImportError) as exc_info:
+            await adapter.predict(INPUT_MARKER)
+
+        message = str(exc_info.value)
+        assert self.optional_sdk_module in message
+        assert self.optional_sdk_extra is not None
+        assert self.optional_sdk_extra in message

--- a/tests/model_adapter_contract.py
+++ b/tests/model_adapter_contract.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-FileCopyrightText: 2026 Abhinav Garg
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-PackageName: rai-toolkit
 

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -15,6 +15,7 @@ import pytest
 import rai_toolkit.models as models_pkg
 from rai_toolkit.models import AnthropicModel
 from rai_toolkit.models import anthropic as anthropic_module
+from tests.model_adapter_contract import ModelAdapterContractTests
 
 anthropic = pytest.importorskip("anthropic")
 
@@ -324,3 +325,34 @@ async def test_predict_raises_helpful_error_without_sdk(
 
     with pytest.raises(ImportError, match="anthropic"):
         await model.predict("Review this answer.")
+
+
+class TestAnthropicContract(ModelAdapterContractTests):
+    """Run the shared adapter conformance suite against this adapter."""
+
+    adapter_module = anthropic_module
+    optional_sdk_module = "anthropic"
+    optional_sdk_extra = "[anthropic]"
+    secret_values = ("secret-test-key",)
+
+    def make_adapter(self) -> AnthropicModel:
+        # The client stays lazy: the autouse fixture has already patched
+        # ``AsyncAnthropic``, so the first call builds a mocked transport,
+        # and the optional-SDK tests can still remove the package first.
+        return AnthropicModel(
+            model="claude-sonnet-4-5",
+            base_url="https://proxy.example/v1",
+            api_key="secret-test-key",
+        )
+
+    def provider_calls(self, adapter: AnthropicModel) -> list[dict[str, Any]]:
+        return adapter.client.messages.calls
+
+    def set_transport_error(self, adapter: AnthropicModel, error: Exception) -> None:
+        async def failing_create(**kwargs: Any) -> None:
+            raise error
+
+        adapter.client.messages.create = failing_create
+
+    def expected_output(self, adapter: AnthropicModel) -> str:
+        return "offline answer"

--- a/tests/test_openai_compatible.py
+++ b/tests/test_openai_compatible.py
@@ -11,6 +11,7 @@ from typing import Any, ClassVar
 import pytest
 
 from rai_toolkit.models import openai_compatible
+from tests.model_adapter_contract import ModelAdapterContractTests
 
 
 class FakeCompletions:
@@ -240,3 +241,37 @@ def test_from_args_normalizes_optional_values_and_temperature(
     assert model.temperature == expected["temperature"]
     assert model.name == expected["name"]
     assert latest_client().kwargs == expected["client_kwargs"]
+
+
+class TestOpenAICompatibleContract(ModelAdapterContractTests):
+    """Run the shared adapter conformance suite against this adapter."""
+
+    adapter_module = openai_compatible
+    secret_values = ("secret-test-key",)
+
+    def make_adapter(self) -> openai_compatible.OpenAICompatibleModel:
+        return openai_compatible.OpenAICompatibleModel(
+            model="local-model",
+            base_url="http://localhost:8000/v1",
+            api_key="secret-test-key",
+        )
+
+    def provider_calls(
+        self, adapter: openai_compatible.OpenAICompatibleModel
+    ) -> list[dict[str, Any]]:
+        return adapter._client.completions.calls
+
+    def set_transport_error(
+        self,
+        adapter: openai_compatible.OpenAICompatibleModel,
+        error: Exception,
+    ) -> None:
+        async def failing_create(**kwargs: Any) -> None:
+            raise error
+
+        adapter._client.completions.create = failing_create
+
+    def expected_output(
+        self, adapter: openai_compatible.OpenAICompatibleModel
+    ) -> str:
+        return "offline answer"


### PR DESCRIPTION
Closes #59

Adds the documented model adapter contract and a reusable, fully offline conformance test suite, exercised against both in-tree adapters.

What's included:

docs/model_adapters.md — adapter contract covering predict semantics, context handling, output fidelity, standard metadata keys, credential redaction, tracing, lazy imports, error propagation, and from_args() factories
tests/model_adapter_contract.py — reusable conformance suite (provider-SDK-agnostic, fully mocked)
Updated tests/test_openai_compatible.py and tests/test_anthropic.py to exercise the conformance suite while retaining all existing provider-specific tests
Updated CONTRIBUTING.md with a link to the adapter guide

Local validation:

python -m pytest -q tests/model_adapter_contract.py tests/test_openai_compatible.py tests/test_anthropic.py
83 passed, 2 skipped

python -m pytest -q
180 passed, 6 skipped (4 skips pre-existing)

python -m ruff check --select E9,F63,F7,F82 .
All checks passed!

reuse --no-multiprocessing lint
Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)

git diff --check
(clean — CRLF auto-convert warnings only)