### PR TITLE
feat(models): add a vendor-neutral CallableModel adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,52 @@ Built-in adapters send `system_prompt` as trusted system instructions. When
 data instead of promoting it to the system channel. This preserves the role
 boundary, but does not by itself prevent prompt injection.
 
+### Evaluating your own inference function
+
+`CallableModel` wraps any function you already have, so an in-process model,
+an internal SDK, or a proprietary endpoint can be assessed without writing a
+`BaseModel` subclass or adding a provider dependency.
+
+```python
+import asyncio
+
+from rai_toolkit.models import CallableModel, ModelResponse
+
+
+def my_model(input_text: str, context: str = "", **kwargs) -> str:
+    """Return a plain string and the adapter wraps it."""
+    return internal_sdk.complete(input_text)
+
+
+def my_model_with_metadata(input_text: str, context: str = "", **kwargs):
+    """Return a ModelResponse to carry your own metadata through unchanged."""
+    reply = internal_sdk.complete(input_text)
+    return ModelResponse(
+        output=reply.text,
+        metadata={"model": reply.model, "total_tokens": reply.usage.total},
+    )
+
+
+async def main() -> None:
+    model = CallableModel(my_model, name="internal-sdk-v2")
+    print((await model.predict("Review this answer.", context="Policy text")).output)
+
+    detailed = CallableModel(my_model_with_metadata)
+    print((await detailed.predict("Review this answer.")).metadata)
+
+
+asyncio.run(main())
+```
+
+Synchronous functions run on a worker thread so they do not block the event
+loop; `async def` functions are awaited directly. The callable is always
+invoked as `predict_fn(input_text, context=context, **kwargs)` and its
+signature is never inspected, so adapt a differently shaped function yourself:
+
+```python
+model = CallableModel(lambda text, context="", **kwargs: legacy_predict(text))
+```
+
 Running fully self-hosted or air-gapped? See [docs/self_hosted.md](docs/self_hosted.md).
 
 ## Quickstart

--- a/rai_toolkit/models/__init__.py
+++ b/rai_toolkit/models/__init__.py
@@ -6,6 +6,13 @@
 
 from rai_toolkit.models.anthropic import AnthropicModel
 from rai_toolkit.models.base import BaseModel, ModelResponse
+from rai_toolkit.models.callable import CallableModel
 from rai_toolkit.models.openai_compatible import OpenAICompatibleModel
 
-__all__ = ["AnthropicModel", "BaseModel", "ModelResponse", "OpenAICompatibleModel"]
+__all__ = [
+    "AnthropicModel",
+    "BaseModel",
+    "CallableModel",
+    "ModelResponse",
+    "OpenAICompatibleModel",
+]

--- a/rai_toolkit/models/callable.py
+++ b/rai_toolkit/models/callable.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2026 M4h1m4
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+"""Vendor-neutral adapter wrapping a user-supplied inference function."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+from rai_toolkit.models.base import BaseModel, ModelResponse
+
+__all__ = ["CallableModel"]
+
+
+class CallableModel(BaseModel):
+    """Evaluate anything callable without writing a :class:`BaseModel` subclass.
+
+    An in-process model, an internal SDK, or a proprietary endpoint becomes
+    gradeable by handing over the function that calls it. No provider
+    dependency is added, and no adapter has to be written per platform.
+
+    Example::
+
+        def my_model(prompt: str, context: str = "", **kwargs: Any) -> str:
+            return internal_sdk.complete(prompt)
+
+        model = CallableModel(my_model)
+
+    The callable is always invoked as
+    ``predict_fn(input_text, context=context, **kwargs)``. Its signature is
+    never inspected, so a function shaped differently is adapted by the caller
+    rather than guessed at here::
+
+        model = CallableModel(lambda text, context="", **kw: legacy(text))
+
+    Guessing would mean deciding which arguments a user "really" wanted, and
+    silently dropping the rest. Passing everything and letting Python raise
+    keeps that decision with the person who wrote the function.
+    """
+
+    def __init__(
+        self,
+        predict_fn: Callable[..., Any],
+        *,
+        name: str | None = None,
+    ) -> None:
+        # Rejected here rather than at the first call: the failure belongs to
+        # the line that built the model, not to an evaluation run started
+        # later, where it would surface as a row error instead of a setup one.
+        if not callable(predict_fn):
+            raise TypeError(
+                "predict_fn must be callable, got "
+                f"{type(predict_fn).__name__}"
+            )
+        super().__init__(name)
+        self._predict_fn = predict_fn
+
+    async def predict(
+        self,
+        input_text: str,
+        context: str = "",
+        **kwargs: Any,
+    ) -> ModelResponse:
+        """Call the wrapped function and normalize what it returns.
+
+        Native coroutine functions are awaited directly. Everything else runs
+        on a worker thread, because a synchronous function doing real work -
+        a network round trip, a local model - would otherwise hold the event
+        loop for its whole duration and stall every other task in the process.
+
+        A synchronous function may still return an awaitable. The thread hop
+        happens first and the result is awaited afterwards, so the blocking
+        part runs off the loop either way; awaiting on the loop directly would
+        leave a blocking factory blocking it. Building a coroutine does not
+        run it and coroutines are not bound to a thread, so one created on the
+        worker is safe to await here.
+        """
+        if inspect.iscoroutinefunction(self._predict_fn):
+            result = await self._predict_fn(input_text, context=context, **kwargs)
+        else:
+            result = await asyncio.to_thread(
+                self._predict_fn, input_text, context=context, **kwargs
+            )
+            # Reached by a callable object whose ``__call__`` is async, and by
+            # any synchronous wrapper around an async client:
+            # ``iscoroutinefunction`` reports False for both.
+            if inspect.isawaitable(result):
+                result = await result
+
+        # Checked before ``str``: ModelResponse is not a string, but ordering
+        # the branches this way keeps the richer type from ever depending on
+        # the narrower check.
+        if isinstance(result, ModelResponse):
+            return result
+        if isinstance(result, str):
+            # Metadata stays empty rather than being inferred. Provider, token
+            # counts and latency are not knowable from a string, and inventing
+            # them would put unsourced numbers into an assessment report.
+            return ModelResponse(output=result)
+        raise TypeError(
+            f"{self.name} expected the callable to return str or ModelResponse, "
+            f"got {type(result).__name__}"
+        )

--- a/rai_toolkit/models/callable.py
+++ b/rai_toolkit/models/callable.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2026 M4h1m4
-# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-PackageName: rai-toolkit
 

--- a/tests/test_callable_model.py
+++ b/tests/test_callable_model.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: 2026 M4h1m4
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+import asyncio
+import functools
+import threading
+from typing import Any
+
+import pytest
+
+from rai_toolkit.models import CallableModel, ModelResponse
+
+
+def _run(model: CallableModel, *args: Any, **kwargs: Any) -> ModelResponse:
+    return asyncio.run(model.predict(*args, **kwargs))
+
+
+# --- the callable receives what it was promised -----------------------------
+
+
+def test_a_sync_callable_receives_input_context_and_keywords() -> None:
+    seen: dict[str, Any] = {}
+
+    def predict_fn(input_text: str, context: str = "", **kwargs: Any) -> str:
+        seen.update(
+            input_text=input_text,
+            context=context,
+            kwargs=kwargs,
+            thread=threading.current_thread().name,
+        )
+        return "ok"
+
+    result = _run(CallableModel(predict_fn), "q", context="ctx", temperature=0.5)
+
+    assert result.output == "ok"
+    assert seen["input_text"] == "q"
+    assert seen["context"] == "ctx"
+    assert seen["kwargs"] == {"temperature": 0.5}
+
+
+def test_a_sync_callable_runs_off_the_event_loop() -> None:
+    # A synchronous function doing real work would otherwise hold the loop for
+    # its whole duration and stall every other task in the process.
+    seen: dict[str, Any] = {}
+
+    def predict_fn(input_text: str, context: str = "", **kwargs: Any) -> str:
+        seen["thread"] = threading.current_thread()
+        return "ok"
+
+    async def main() -> None:
+        seen["loop_thread"] = threading.current_thread()
+        await CallableModel(predict_fn).predict("q")
+
+    asyncio.run(main())
+
+    assert seen["thread"] is not seen["loop_thread"]
+
+
+def test_an_async_callable_receives_and_returns_the_same_values() -> None:
+    seen: dict[str, Any] = {}
+
+    async def predict_fn(input_text: str, context: str = "", **kwargs: Any) -> str:
+        seen.update(input_text=input_text, context=context, kwargs=kwargs)
+        return "async ok"
+
+    result = _run(CallableModel(predict_fn), "q", context="ctx", top_p=0.9)
+
+    assert result.output == "async ok"
+    assert seen == {"input_text": "q", "context": "ctx", "kwargs": {"top_p": 0.9}}
+
+
+def test_context_is_forwarded_even_when_empty() -> None:
+    # Always forwarded rather than omitted when blank: a callable that declares
+    # context must not see a different call shape depending on the row.
+    seen: dict[str, Any] = {}
+
+    def predict_fn(input_text: str, context: str = "sentinel", **kwargs: Any) -> str:
+        seen["context"] = context
+        return "ok"
+
+    _run(CallableModel(predict_fn), "q")
+
+    assert seen["context"] == ""
+
+
+def test_a_signature_that_does_not_accept_context_is_not_adapted() -> None:
+    # The signature is never inspected, so the mismatch surfaces as Python's
+    # own TypeError. Guessing would mean silently dropping arguments the user
+    # asked to pass.
+    def predict_fn(input_text: str) -> str:
+        return "ok"
+
+    with pytest.raises(TypeError):
+        _run(CallableModel(predict_fn), "q")
+
+
+# --- every callable shape ---------------------------------------------------
+
+
+def test_a_partial_is_treated_as_the_function_it_wraps() -> None:
+    async def predict_fn(prefix: str, input_text: str, context: str = "") -> str:
+        return f"{prefix}:{input_text}"
+
+    model = CallableModel(functools.partial(predict_fn, "p"))
+
+    assert _run(model, "q").output == "p:q"
+
+
+def test_a_callable_object_is_accepted() -> None:
+    class Predictor:
+        def __call__(self, input_text: str, context: str = "", **kwargs: Any) -> str:
+            return f"obj:{input_text}"
+
+    assert _run(CallableModel(Predictor()), "q").output == "obj:q"
+
+
+def test_a_sync_wrapper_returning_an_awaitable_is_awaited() -> None:
+    # inspect.iscoroutinefunction reports False for this, so the awaitable is
+    # only discovered from what came back.
+    async def inner(input_text: str) -> str:
+        return f"inner:{input_text}"
+
+    def predict_fn(input_text: str, context: str = "", **kwargs: Any) -> Any:
+        return inner(input_text)
+
+    assert _run(CallableModel(predict_fn), "q").output == "inner:q"
+
+
+def test_an_async_callable_object_is_awaited() -> None:
+    class Predictor:
+        async def __call__(
+            self, input_text: str, context: str = "", **kwargs: Any
+        ) -> str:
+            return f"aobj:{input_text}"
+
+    assert _run(CallableModel(Predictor()), "q").output == "aobj:q"
+
+
+def test_the_blocking_part_of_an_awaitable_factory_runs_off_the_loop() -> None:
+    # to_thread happens first and the awaitable is awaited afterwards, so work
+    # done before the coroutine is built does not block the loop.
+    seen: dict[str, Any] = {}
+
+    async def inner() -> str:
+        return "ok"
+
+    def predict_fn(input_text: str, context: str = "", **kwargs: Any) -> Any:
+        seen["factory_thread"] = threading.current_thread()
+        return inner()
+
+    async def main() -> None:
+        seen["loop_thread"] = threading.current_thread()
+        await CallableModel(predict_fn).predict("q")
+
+    asyncio.run(main())
+
+    assert seen["factory_thread"] is not seen["loop_thread"]
+
+
+# --- result normalization ---------------------------------------------------
+
+
+def test_a_string_becomes_a_response_with_empty_metadata() -> None:
+    # Provider, token counts and latency are not knowable from a string, and
+    # inventing them would put unsourced numbers into an assessment report.
+    result = _run(CallableModel(lambda t, context="", **kw: "text"), "q")
+
+    assert isinstance(result, ModelResponse)
+    assert result.output == "text"
+    assert result.metadata == {}
+
+
+def test_a_returned_response_is_preserved_unchanged() -> None:
+    response = ModelResponse(output="out", metadata={"model": "custom", "tokens": 7})
+
+    result = _run(CallableModel(lambda t, context="", **kw: response), "q")
+
+    assert result is response
+    assert result.metadata == {"model": "custom", "tokens": 7}
+
+
+@pytest.mark.parametrize(
+    "value", [None, {"output": "x"}, b"bytes", 42, ["a"], ("a",), 1.5, True]
+)
+def test_an_unsupported_result_raises_naming_both_types(value: Any) -> None:
+    model = CallableModel(lambda t, context="", **kw: value)
+
+    with pytest.raises(TypeError) as excinfo:
+        _run(model, "q")
+
+    message = str(excinfo.value)
+    assert "str or ModelResponse" in message
+    assert type(value).__name__ in message
+
+
+# --- failures stay the caller's ---------------------------------------------
+
+
+def test_a_sync_exception_propagates_unwrapped() -> None:
+    def predict_fn(input_text: str, context: str = "", **kwargs: Any) -> str:
+        raise ValueError("upstream failure")
+
+    with pytest.raises(ValueError, match="upstream failure"):
+        _run(CallableModel(predict_fn), "q")
+
+
+def test_an_async_exception_propagates_unwrapped() -> None:
+    async def predict_fn(input_text: str, context: str = "", **kwargs: Any) -> str:
+        raise RuntimeError("async upstream failure")
+
+    with pytest.raises(RuntimeError, match="async upstream failure"):
+        _run(CallableModel(predict_fn), "q")
+
+
+@pytest.mark.parametrize("value", [None, "not callable", 42, object()])
+def test_a_non_callable_is_rejected_at_construction(value: Any) -> None:
+    # Rejected when the model is built, not when a row is scored, so the error
+    # points at the line that made the mistake.
+    with pytest.raises(TypeError, match="must be callable"):
+        CallableModel(value)
+
+
+# --- naming and tracing -----------------------------------------------------
+
+
+def test_an_explicit_name_is_used() -> None:
+    model = CallableModel(lambda t, context="", **kw: "x", name="internal-sdk-v2")
+
+    assert model.name == "internal-sdk-v2"
+
+
+def test_the_default_name_falls_back_to_the_class() -> None:
+    assert CallableModel(lambda t, context="", **kw: "x").name == "CallableModel"
+
+
+def test_predict_carries_the_inherited_trace_exactly_once() -> None:
+    # BaseModel.__init_subclass__ wraps predict already. Adding a second
+    # decorator here would take the op name over and double the span.
+    assert (
+        getattr(CallableModel.predict, "__rai_traced_op_name__", None)
+        == "rai.model.predict"
+    )
+
+
+def test_the_adapter_adds_no_import_time_dependency() -> None:
+    import rai_toolkit.models.callable as module
+
+    source = module.__file__
+    assert source is not None
+    with open(source, encoding="utf-8") as handle:
+        text = handle.read()
+    for third_party in ("import openai", "import anthropic", "import httpx"):
+        assert third_party not in text


### PR DESCRIPTION

Closes #60.

Wraps a user-supplied inference function so an in-process model, an internal SDK, or a proprietary endpoint can be assessed without writing a `BaseModel` subclass or adding a provider dependency.

```python
model = CallableModel(my_predict_fn, name="internal-sdk-v2")
result = await model.predict("Review this answer.", context="Policy text")
```

## Dispatch

Native coroutine functions are awaited directly. Everything else goes through `asyncio.to_thread`, so a synchronous function doing a network round trip does not hold the loop.

A synchronous callable can still return an awaitable, and `inspect.iscoroutinefunction` reports `False` both for a callable object with an `async __call__` and for a sync wrapper around an async client — so the dispatch cannot be decided from the function alone:

```python
result = await asyncio.to_thread(fn, input_text, context=context, **kwargs)
if inspect.isawaitable(result):
    result = await result
```

**One thing to confirm.** The criteria say to run synchronous callables with `to_thread` "so they do not block the event loop", and separately that an awaitable result is awaited before normalization, without fixing the sequence. Thread hop first is the reading that makes the first rule hold in the mixed case — awaiting on the loop directly would leave a blocking factory blocking it. Building a coroutine does not run it and coroutines are not thread-bound, so one created on the worker is safe to await on the loop. If you meant the other order, say so and I will switch.

## Everything else follows the criteria

The signature is never inspected, so a mismatch surfaces as Python's own `TypeError` and the caller adapts with a lambda or `partial`. A string becomes a response with empty metadata rather than an inferred one. A `ModelResponse` passes through untouched. Anything else raises `TypeError` naming both types. Exceptions propagate unchanged, a non-callable is rejected at construction, and `predict` is left for `BaseModel.__init_subclass__` so the trace stays single. `pyproject.toml` is untouched.

## Testing

30 offline tests covering the ten scenarios listed, plus three beyond them: that `context` is forwarded when empty, that a signature without `context` is left to raise rather than adapted, and that the blocking half of an awaitable factory runs off the loop.

Each guarantee was checked by removing it and confirming failures — dropping `to_thread` fails 2 tests, the awaitable await 3, the eager callable check 4, empty metadata 1, and raising on an unsupported result 8.

```
pytest -q tests/test_callable_model.py tests/test_openai_compatible.py   40 passed
pytest -q                                                               142 passed, 5 skipped
ruff check --select E9,F63,F7,F82 .                                     clean
reuse --no-multiprocessing lint                                         compliant
git diff --check                                                        clean
```

Branched directly on `6d0ed0c`.

## AI assistance

This contribution was AI-assisted (Claude). The design decisions and the dispatch reasoning above were worked through and reviewed by me, and I can explain or rework any line.
