### PR TITLE
fix(scorers): reject non-finite normalized scores

### DIFF
--- a/rai_toolkit/scorers/base.py
+++ b/rai_toolkit/scorers/base.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
@@ -36,8 +37,10 @@ class ScorerResult:
     assessed: bool = True
 
     def __post_init__(self) -> None:
-        if not 0.0 <= self.score <= 1.0:
-            raise ValueError(f"Score must be between 0.0 and 1.0, got {self.score}")
+        if not math.isfinite(self.score) or not (0.0 <= self.score <= 1.0):
+            raise ValueError(
+                f"Score must be a finite number between 0.0 and 1.0, got {self.score}"
+            )
 
 
 class BaseScorer(ABC):

--- a/rai_toolkit/scorers/llm_judges.py
+++ b/rai_toolkit/scorers/llm_judges.py
@@ -181,6 +181,21 @@ class LLMJudgeScorer(BaseScorer):
         result = self._call_judge(prompts["system"], user_prompt)
 
         raw_score = float(result.get("score", 0))
+        if not math.isfinite(raw_score):
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation="Judge returned non-finite score; marked un-assessed.",
+                details={
+                    "scorer_name": self.name,
+                    "raw_score": raw_score,
+                    "max_score": 3,
+                    "judge_model": self.model,
+                    "judge_response": result,
+                },
+                assessed=False,
+            )
         normalized = ScoreNormalizer.from_compliance_scale(raw_score)
         passed = ScoreNormalizer.apply_threshold(normalized, self.threshold)
 
@@ -390,6 +405,23 @@ class GroundednessScorer(LLMJudgeScorer):
         user_prompt = self._format_prompt(output=output, input=input, context=context)
         result = self._call_judge(prompts["system"], user_prompt)
         raw_score = float(result.get("score", 0))
+        if not math.isfinite(raw_score):
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation="Judge returned non-finite score; marked un-assessed.",
+                details={
+                    "skipped": "non_finite_judge_score",
+                    "scorer_name": self.name,
+                    "raw_score": raw_score,
+                    "max_score": 3,
+                    "judge_model": self.model,
+                    "supporting_spans": [],
+                    "contradicting_spans": [],
+                },
+                assessed=False,
+            )
         normalized = ScoreNormalizer.from_compliance_scale(raw_score)
         raw_supporting = result.get("supporting_spans")
         raw_contradicting = result.get("contradicting_spans")

--- a/rai_toolkit/scorers/normalizer.py
+++ b/rai_toolkit/scorers/normalizer.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import math
+
 from rai_toolkit.scorers.base import ScorerResult
 
 
@@ -33,8 +35,12 @@ class ScoreNormalizer:
         Returns:
             Normalized score between 0.0 and 1.0.
         """
-        if max_value <= 0:
-            raise ValueError(f"max_value must be positive, got {max_value}")
+        if not math.isfinite(raw_score):
+            raise ValueError(f"raw_score must be finite, got {raw_score}")
+        if not math.isfinite(max_value) or max_value <= 0:
+            raise ValueError(
+                f"max_value must be a finite positive number, got {max_value}"
+            )
         normalized = max(0.0, min(1.0, raw_score / max_value))
         return 1.0 - normalized if invert else normalized
 
@@ -69,18 +75,22 @@ class ScoreNormalizer:
             results: List of ScorerResult objects.
             weights: Optional dict mapping category -> weight. Defaults to equal weights.
 
+        Un-assessed results are skipped entirely: their placeholder scores
+        are not a signal and must not dilute the real ones.
+
         Returns:
             Weighted average score between 0.0 and 1.0.
         """
-        if not results:
+        assessed = [r for r in results if r.assessed]
+        if not assessed:
             return 0.0
 
         if weights is None:
-            return sum(r.score for r in results) / len(results)
+            return sum(r.score for r in assessed) / len(assessed)
 
         total_weight = 0.0
         weighted_sum = 0.0
-        for result in results:
+        for result in assessed:
             w = weights.get(result.category, 1.0)
             weighted_sum += result.score * w
             total_weight += w

--- a/tests/test_nonfinite_scores.py
+++ b/tests/test_nonfinite_scores.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Abhinav Garg
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: rai-toolkit
+
+"""Non-finite scores must be rejected at every layer, not silently averaged in."""
+
+from __future__ import annotations
+
+import pytest
+
+from rai_toolkit.scorers.base import ScorerResult
+from rai_toolkit.scorers.normalizer import ScoreNormalizer
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_scorer_result_rejects_nonfinite(bad_value: float) -> None:
+    with pytest.raises(ValueError, match="finite"):
+        ScorerResult(score=bad_value, passed=False, category="test", explanation="x")
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_normalizer_from_scale_rejects_nonfinite_raw_score(bad_value: float) -> None:
+    with pytest.raises(ValueError, match="finite"):
+        ScoreNormalizer.from_scale(bad_value, max_value=3.0)
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_normalizer_from_scale_rejects_nonfinite_max_value(bad_value: float) -> None:
+    with pytest.raises(ValueError):
+        ScoreNormalizer.from_scale(1.0, max_value=bad_value)
+
+
+def test_aggregate_scores_skips_unassessed_results() -> None:
+    results = [
+        ScorerResult(
+            score=0.8, passed=True, category="a", explanation="ok", assessed=True
+        ),
+        ScorerResult(
+            score=0.6, passed=True, category="b", explanation="ok", assessed=True
+        ),
+        ScorerResult(
+            score=0.0, passed=False, category="c", explanation="skip", assessed=False
+        ),
+    ]
+    avg = ScoreNormalizer.aggregate_scores(results)
+    # Should average only the two assessed results: (0.8 + 0.6) / 2 = 0.7
+    assert avg == pytest.approx(0.7)
+
+
+def test_aggregate_scores_weighted_skips_unassessed_results() -> None:
+    results = [
+        ScorerResult(
+            score=0.8, passed=True, category="a", explanation="ok", assessed=True
+        ),
+        ScorerResult(
+            score=0.0, passed=False, category="b", explanation="skip", assessed=False
+        ),
+    ]
+    avg = ScoreNormalizer.aggregate_scores(results, weights={"a": 2.0, "b": 5.0})
+    assert avg == pytest.approx(0.8)
+
+
+def test_aggregate_scores_all_unassessed_returns_zero() -> None:
+    results = [
+        ScorerResult(
+            score=0.0, passed=False, category="a", explanation="skip", assessed=False
+        ),
+    ]
+    assert ScoreNormalizer.aggregate_scores(results) == 0.0
+
+
+def test_aggregate_scores_empty_returns_zero() -> None:
+    assert ScoreNormalizer.aggregate_scores([]) == 0.0
+
+
+# Regression guards -- valid values still work
+@pytest.mark.parametrize("good_value", [0.0, 0.5, 1.0])
+def test_scorer_result_accepts_valid_finite_scores(good_value: float) -> None:
+    result = ScorerResult(
+        score=good_value, passed=True, category="test", explanation="ok"
+    )
+    assert result.score == good_value
+
+
+def test_normalizer_from_scale_valid() -> None:
+    assert ScoreNormalizer.from_scale(2.0, max_value=3.0) == pytest.approx(2.0 / 3.0)


### PR DESCRIPTION
Closes https://github.com/wandb/rai-toolkit/issues/38

What
Non-finite values (NaN, +inf, -inf) can enter the scoring pipeline
from malformed LLM judge responses. These values poison score aggregations
and can silently pass or fail policy gates.

Fix
ScorerResult.__post_init__: explicit math.isfinite() guard alongside
the range check, with a clearer error message
ScoreNormalizer.from_scale: reject non-finite raw_score and max_value
before normalization
ScoreNormalizer.aggregate_scores: filter to assessed=True results only,
preventing un-assessed placeholders from diluting real scores
LLMJudgeScorer.score: catch non-finite raw judge scores and return
assessed=False rather than propagating the bad value
Parametrized tests for NaN, +inf, -inf at each validation layer
Regression guards confirming valid scores still work
AI disclosure
Implementation assisted by Claude. All code reviewed and tested locally.

Local validation
pytest tests/test_nonfinite_scores.py -v
17 passed

pytest tests/ -x -q
343 passed, 14 skipped