### PR TITLE
docs: explain current scorer and callable contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,13 @@
 !/.reuse/**
 !/pyproject.toml
 !/CONTRIBUTING.md
+!/CONTRIBUTORS.md
 !/CODE_OF_CONDUCT.md
+!/docs/
+!/docs/model_adapters.md
+!/docs/policy_packs.md
+!/docs/scorer_authoring.md
+!/docs/self_hosted.md
 !/.github/
 !/.github/**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,13 @@ local validation are complete.
 - AI-assisted contributions are fine. Say so in the pull request description,
   and be ready to explain and rework any line when asked.
 
+## Scorer contributions
+
+When adding a scorer, follow the [scorer-authoring guide](docs/scorer_authoring.md)
+for the result contract, unassessed rows, evidence validation, and offline tests.
+
 ## License headers
+
 <!--- REUSE-IgnoreStart -->
 
 Every source file carries an SPDX header reflecting:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,39 @@
+<!--
+SPDX-FileCopyrightText: 2026 Karan Nisar
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: rai-toolkit
+-->
+
+# Contributors
+
+Thank you to everyone contributing code, tests, documentation, bug reports, and
+review to rai-toolkit. The table below credits merged contributions verified
+against `main` through September 12, 2026. It is alphabetical by GitHub handle
+and is not a ranking or a complete record of non-code contributions.
+
+Karan Nisar ([@knisar](https://github.com/knisar)) created and maintains the
+toolkit. Community contributions include:
+
+| Contributor | Merged work |
+| --- | --- |
+| [@a0927929980-dot](https://github.com/a0927929980-dot) | Groundedness handling for behavioral refusals ([#17](https://github.com/wandb/rai-toolkit/pull/17)) |
+| [@abhnvgrg](https://github.com/abhnvgrg) | Model adapter contract documentation and conformance suite ([#61](https://github.com/wandb/rai-toolkit/pull/61)) |
+| [@adity982](https://github.com/adity982) | Groundedness scorer with verified evidence ([#13](https://github.com/wandb/rai-toolkit/pull/13)) |
+| [@denis-samatov](https://github.com/denis-samatov) | HR industry preset ([#24](https://github.com/wandb/rai-toolkit/pull/24)) |
+| [@dvd233](https://github.com/dvd233) | Explicit adapter call-time options ([#65](https://github.com/wandb/rai-toolkit/pull/65)) |
+| [@EffNine](https://github.com/EffNine) | Configured scorer names in Weave ([#33](https://github.com/wandb/rai-toolkit/pull/33)) |
+| [@M4h1m4](https://github.com/M4h1m4) | Vendor-neutral `CallableModel` adapter ([#64](https://github.com/wandb/rai-toolkit/pull/64)) |
+| [@nightcityblade](https://github.com/nightcityblade) | Normalized groundedness evidence matching ([#18](https://github.com/wandb/rai-toolkit/pull/18)) |
+| [@robbat2](https://github.com/robbat2) | Dependency-license documentation and HealthBench citations ([#1](https://github.com/wandb/rai-toolkit/pull/1)) |
+| [@sansynx](https://github.com/sansynx) | Example validation and offline CLI tests ([#46](https://github.com/wandb/rai-toolkit/pull/46), [#47](https://github.com/wandb/rai-toolkit/pull/47)) |
+| [@schallten](https://github.com/schallten) | Anthropic Messages API adapter ([#56](https://github.com/wandb/rai-toolkit/pull/56)) |
+| [@Srijan229](https://github.com/Srijan229) | Shared package and report version source ([#54](https://github.com/wandb/rai-toolkit/pull/54)) |
+| [@TheJhyeFactor](https://github.com/TheJhyeFactor) | OpenAI-compatible adapter tests ([#48](https://github.com/wandb/rai-toolkit/pull/48)) |
+| [@TrueFurina](https://github.com/TrueFurina) | Four red-team attack templates ([#11](https://github.com/wandb/rai-toolkit/pull/11)) |
+| [@YusefSyed](https://github.com/YusefSyed) | Judge categories, additional Weave scorers, async and unassessed composite results, and preset policy isolation ([#30](https://github.com/wandb/rai-toolkit/pull/30), [#31](https://github.com/wandb/rai-toolkit/pull/31), [#51](https://github.com/wandb/rai-toolkit/pull/51), [#52](https://github.com/wandb/rai-toolkit/pull/52)) |
+| [@Zeming-Yuan](https://github.com/Zeming-Yuan) | Retrieval relevance, context precision, and context recall scorers ([#37](https://github.com/wandb/rai-toolkit/pull/37), [#58](https://github.com/wandb/rai-toolkit/pull/58)) |
+
+For later changes and the underlying commit record, see the
+[contributor history](https://github.com/wandb/rai-toolkit/graphs/contributors)
+and [merged pull requests](https://github.com/wandb/rai-toolkit/pulls?q=is%3Apr+is%3Amerged).
+Please open a pull request to correct a handle, attribution, or missing credit.

--- a/README.md
+++ b/README.md
@@ -384,6 +384,18 @@ boundary, but does not by itself prevent prompt injection.
 an internal SDK, or a proprietary endpoint can be assessed without writing a
 `BaseModel` subclass or adding a provider dependency.
 
+`CallableModel` passes `input_text`, `context`, and call-time options to your
+function unchanged. It does not build a provider request, choose message roles,
+or add the built-in adapters' context handling policy. Your function owns that
+boundary: keep retrieved context out of system instructions and other privileged
+channels, and pass it as separate, lower-trust data. Record how the function
+constructs its prompt before comparing injection-resistance results with a
+built-in adapter; wrapping a function does not establish equivalent prompt
+handling. See the [callable contract](docs/model_adapters.md#wrapping-a-callable).
+
+The examples below demonstrate return types and do not use `context`. For a RAG
+assessment, adapt the function to supply the retrieved context to its model.
+
 ```python
 import asyncio
 
@@ -490,7 +502,8 @@ a domain without forking scorer code.
 
 Available judge scorers include `FactualityJudge`, `FairnessJudge`,
 `ContentSafetyJudge`, `PrivacyJudge`, `SecurityJudge`, `TransparencyJudge`,
-`ExplainabilityJudge`, `RubricScorer`, and `GroundednessScorer`. The
+`ExplainabilityJudge`, `RubricScorer`, `GroundednessScorer`,
+`RetrievalRelevanceScorer`, `ContextPrecisionScorer`, and `ContextRecallScorer`. The
 `GroundednessScorer` evaluates RAG responses only when retrieved context is
 present and retains verified supporting or contradicting spans as evidence.
 The `RetrievalRelevanceScorer` grades retrieval quality itself: it validates
@@ -502,6 +515,10 @@ chunk by chunk: precision reports the fraction of retrieved chunks the query
 actually needed, and recall reports how much of the row's reference answer the
 retrieval supplied. Both derive their score from validated verdicts, so a
 judge that cannot be trusted leaves the row un-assessed instead of scoring it.
+
+For custom scorers, see the [scorer-authoring guide](docs/scorer_authoring.md),
+including result semantics, verified evidence, retrieval-score denominators,
+and offline validation.
 
 ## Weave-native evaluation in assessment
 
@@ -612,6 +629,16 @@ PRs welcome. New here? Check the [good first issue](https://github.com/wandb/rai
 - More red-team attack templates (with responsible disclosure)
 - Stronger LLM-judge coverage and prompts under `rai_toolkit/prompts`
 - Additional industry presets beyond the bundled healthcare / finance / government / HR set
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution workflow and the
+[scorer-authoring guide](docs/scorer_authoring.md) for custom evaluation work.
+
+## Acknowledgments
+
+The toolkit includes community contributions to model adapters, scorers,
+industry presets, red-team templates, tests, and documentation. See
+[CONTRIBUTORS.md](CONTRIBUTORS.md) for contributor handles and links to merged
+work, and the [full contributor history](https://github.com/wandb/rai-toolkit/graphs/contributors).
 
 
 ## License

--- a/docs/model_adapters.md
+++ b/docs/model_adapters.md
@@ -2,7 +2,43 @@
 
 A model adapter is the seam between the toolkit and whatever system actually answers a prompt. Everything downstream — evaluation, red-teaming, guardrails, the assessment report — talks to a `BaseModel` and never to a provider SDK. That only holds if every adapter behaves the same way, so this page is the contract adapters are held to.
 
-The contract has an executable form: `tests/model_adapter_contract.py`. An adapter is not finished until it passes that suite.
+The provider adapter contract has an executable form: `tests/model_adapter_contract.py`. A dedicated provider adapter is not finished until it passes that suite.
+
+The provider request, channel, and standard metadata requirements below describe
+dedicated provider adapters, including `OpenAICompatibleModel` and
+`AnthropicModel`. `CallableModel` is a forwarding wrapper with the narrower
+contract described next; it cannot enforce what an arbitrary function sends to
+its provider.
+
+## Wrapping a callable
+
+`CallableModel` invokes `predict_fn(input_text, context=context, **kwargs)` with
+the caller's values unchanged. It awaits coroutine functions, runs synchronous
+functions on a worker thread, and awaits an awaitable returned by a synchronous
+function. Exceptions propagate. The function must return a string or a
+`ModelResponse`; other return types raise `TypeError`.
+
+The wrapper does not serialize retrieved context, append a context handling
+policy, choose message roles, or validate provider-specific options. The wrapped
+function is responsible for those choices and for delivering context to the
+model. If it uses retrieved context, keep that data out of system instructions
+and other privileged channels. Test the actual provider request constructed by
+the function, including poisoned context and empty-context behavior. The
+provider adapter conformance suite does not establish those properties for an
+arbitrary callable.
+
+Document the callable's prompt construction, context handling, model settings,
+and retrieval configuration alongside its assessment results. An injection test
+of that callable measures the complete implementation, including its choice of
+trust boundaries. It is not an adapter-only comparison with the built-ins unless
+the relevant request construction and assessment conditions are aligned.
+
+A returned `ModelResponse` is preserved, including its metadata. A returned
+string is wrapped with empty metadata; `CallableModel` does not synthesize the
+six provider metadata keys below. Populate them in your function when known. If
+the function retrieves its own context, return the actual context used under
+`metadata["retrieved_context"]` so evaluation can use it instead of the dataset's
+context hint.
 
 ## When you need a dedicated adapter
 
@@ -89,7 +125,7 @@ This structure is defense in depth, not a guarantee. It removes one specific and
 
 ## Standard metadata keys
 
-Every adapter populates these six keys on `ModelResponse.metadata`:
+Every dedicated provider adapter populates these six keys on `ModelResponse.metadata`:
 
 | Key | Meaning |
 | --- | --- |

--- a/docs/scorer_authoring.md
+++ b/docs/scorer_authoring.md
@@ -1,0 +1,206 @@
+<!--
+SPDX-FileCopyrightText: 2026 Karan Nisar
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: rai-toolkit
+-->
+
+# Writing a scorer
+
+A scorer turns one model response and its available evidence into a
+`ScorerResult`. Start with a precise measurement: what is being graded, what
+evidence is required, what a passing result means, and when the row cannot be
+assessed. This guide describes the interfaces and retrieval scorers on `main`.
+The citation-correctness scorer in [PR #27](https://github.com/wandb/rai-toolkit/pull/27)
+is still under review and is not part of this guide's supported API.
+
+## The result contract
+
+Subclass [`BaseScorer`](../rai_toolkit/scorers/base.py) and implement
+`score(output, input="", context="", **kwargs)`. Give the scorer a stable `name`,
+a description, the risk `category` it measures, and a `threshold`.
+Use distinct names for distinct configured scorers: evaluation stores results
+by scorer name, so duplicate names can overwrite results.
+
+| Field | Authoring rule |
+| --- | --- |
+| `score` | A finite number from 0 to 1; higher means better or safer. Validate raw values before normalization. |
+| `passed` | For an assessed row, apply the declared threshold or explicitly document another decision rule. |
+| `category` | The risk category actually measured, such as `MIT-3.1`; this determines aggregation and policy context. |
+| `explanation` | Describe the result or missing evidence in terms a report reader can verify. |
+| `details` | Keep JSON-safe evidence and audit data, including `scorer_name` and any skip reason. |
+| `assessed` | `True` only when the scorer produced a usable measurement. |
+
+Reject non-finite raw values, booleans where a numeric score is expected,
+invalid ranges, and malformed judge output before calling `ScoreNormalizer`.
+Do not rely on normalization to validate these inputs: `from_scale` clips
+values, and broader non-finite validation is still tracked in
+[issue #38](https://github.com/wandb/rai-toolkit/issues/38).
+
+An unassessed row normally uses `score=0.0`, `passed=False`, `assessed=False`,
+and `details["skipped"]` with a stable reason. The zero and false values are
+placeholders, not a measured failure. The evaluation pipeline excludes these
+rows from score and pass-rate aggregates and reports them as coverage gaps.
+Code consuming a result directly must check `assessed` before interpreting it.
+If you use `ScoreNormalizer.aggregate_scores` directly, filter unassessed
+results yourself; that helper does not filter them.
+
+## A small offline example
+
+This scorer measures literal reference-text inclusion. It does not establish
+factual correctness, entailment, or source attribution.
+
+```python
+from rai_toolkit.scorers import BaseScorer, ScorerResult
+
+
+class ReferenceTextScorer(BaseScorer):
+    name = "reference_text"
+    description = "Checks whether the response contains the supplied reference text"
+    category = "MIT-3.1"
+    threshold = 1.0
+
+    def score(self, output, input="", context="", **kwargs):
+        expected = kwargs.get("expected")
+        if not isinstance(expected, str) or not expected.strip():
+            return ScorerResult(
+                score=0.0,
+                passed=False,
+                category=self.category,
+                explanation="Unassessed: a non-empty reference string is required.",
+                details={"scorer_name": self.name, "skipped": "missing_reference"},
+                assessed=False,
+            )
+
+        score = 1.0 if expected in output else 0.0
+        return ScorerResult(
+            score=score,
+            passed=score >= self.threshold,
+            category=self.category,
+            explanation="Reference text found." if score else "Reference text absent.",
+            details={"scorer_name": self.name, "reference_span": expected},
+        )
+
+
+scorer = ReferenceTextScorer()
+result = scorer.score("The limit is 10.", expected="limit is 10")
+assert result.assessed and result.passed
+assert not scorer.score("The limit is 10.").assessed
+```
+
+The built-in pipeline forwards a row's non-empty `expected` and `rubrics`
+values as scorer keyword arguments. It does not forward arbitrary dataset
+columns. For `context`, it prefers the model response's non-empty
+`metadata["retrieved_context"]` over the dataset context. See
+[`RAIEvaluationPipeline`](../rai_toolkit/evaluation/pipeline.py) before adding
+new input requirements.
+
+For asynchronous I/O, implement `score_async` and keep the required `score`
+method's behavior explicit. The base implementation of `score_async` calls
+`score` directly; it does not move blocking work to a worker thread.
+
+## Choose skip rules for the measurement
+
+Missing required context, a missing reference answer, or an unusable judge reply
+is a coverage gap. Return an unassessed result with a specific explanation.
+The pipeline also converts scorer exceptions into unassessed results. Do not
+catch an exception and turn it into a successful score.
+
+Refusal handling depends on what the scorer measures. `GroundednessScorer`
+skips rows whose reference expects refusal or boundary-setting.
+`ContextPrecisionScorer` and `ContextRecallScorer` grade retrieval, so they can
+still assess the context when the generator refuses. Copying a skip rule from
+another scorer without checking the measurement can remove valid evidence.
+
+When introducing a skip reason, check
+[`_classify_unassessed_reason`](../rai_toolkit/assessment/assessor.py). It recognizes
+some reasons explicitly and otherwise falls back to a generic report label.
+Add a report regression if the new reason needs a specific human-facing label.
+
+## Verify evidence before storing it
+
+`GroundednessScorer` records verified evidence in `details["supporting_spans"]`
+and `details["contradicting_spans"]`. Each entry has this shape:
+
+```json
+{
+  "response_span": "Notices are required",
+  "context_span": "Notices are required for denied applicants."
+}
+```
+
+Both strings must be present in the corresponding response or context. The
+existing verifier allows whitespace and quote normalization when matching,
+then stores the matched slice from the original text. A matching quote proves
+that the evidence exists, not that the judge's semantic conclusion is correct.
+Do not use prompt envelopes, source labels alone, or a quotation from another
+source as evidence for the target passage.
+
+For an LLM judge, mock `_call_judge` in offline tests. Check response types,
+required fields, indexes, duplicates, and coverage before calculating a result.
+Keep rejected evidence counts and enough sanitized audit data to explain a
+rejection. When a score cannot be derived safely from the remaining evidence,
+return an unassessed result. State explicitly whether the judge's score is
+authoritative, validated against a rubric, or only advisory.
+
+## Keep retrieval denominators tied to the input
+
+The three retrieval scorers reuse the chunk parsing and envelope rendering in
+[`llm_judges.py`](../rai_toolkit/scorers/llm_judges.py). Their private helpers are
+implementation references, not a stable public parser API.
+
+- `RetrievalRelevanceScorer` grades each parsed chunk independently and derives
+  its aggregate from validated per-chunk verdicts.
+- `ContextPrecisionScorer` divides needed chunks by all parsed chunks. It groups
+  exact duplicate passage content after removing source labels and normalizing
+  whitespace. If any copy is needed, the lowest-index copy is kept as needed;
+  later copies are not. A group with no needed copy stays unnecessary.
+- `ContextRecallScorer` binds each reference item to one occurrence of a verified
+  reference span. Repeated text needs separate occurrences. Items must cover the
+  full reference without overlap; missing, duplicate, or overlapping coverage
+  cannot silently shrink the denominator.
+
+Recall merges adjacent pieces with the same support verdict into stretches on
+the whitespace-normalized reference, then divides supported stretch length by
+total stretch length. Spaces between opposite-verdict stretches are outside
+both lengths. This measures text coverage, not an equally weighted count of
+facts. Equivalent splitting of the same supported or unsupported text must not
+change the score, and adding unsupported reference content must reduce it.
+Evidence for a supported reference item must verify in the original retrieved
+chunk; unverifiable support is downgraded. The original judge score is advisory.
+
+## Add the scorer to an assessment
+
+For a task-specific scorer, pass an instance through `additional_scorers` to
+`Assessor` or `RAIEvaluationPipeline`. For example, after configuring the model,
+datasets, and compliance profile as in the README, add
+`additional_scorers=[ReferenceTextScorer()]` to the constructor.
+This is also how the optional RAG scorers are enabled; exporting a class does
+not register it for every assessment.
+
+For a new built-in scorer, export it from
+[`rai_toolkit.scorers`](../rai_toolkit/scorers/__init__.py). Add it to
+[`SCORER_REGISTRY`](../rai_toolkit/compliance/scorer_registry.py) only when the
+associated compliance profiles should select it by default. Verify resolution
+through the mapping engine and both evaluation backends. A specialized scorer
+that requires inputs most rows lack is usually better left opt-in.
+
+## Validation before review
+
+Use offline cases that distinguish the intended behavior from a plausible bug:
+
+- A measured pass, a measured failure, and missing-evidence cases; guard paths
+  should assert that no judge call was made.
+- Malformed, non-object, contradictory, incomplete, and non-finite judge replies.
+- Evidence that exists, evidence that was invented, and evidence in the wrong
+  passage, retaining the original matched text in accepted results.
+- Duplicate chunks, repeated reference spans, equivalent partitions, and growing
+  missing content when the measurement uses a denominator.
+- Async execution, configured names, and coverage-gap reporting when affected.
+
+Useful examples are [`test_groundedness_scorer.py`](../tests/test_groundedness_scorer.py),
+[`test_retrieval_relevance.py`](../tests/test_retrieval_relevance.py),
+[`test_context_precision_recall.py`](../tests/test_context_precision_recall.py),
+and [`test_composite_scorer.py`](../tests/test_composite_scorer.py).
+Run the affected tests and the checks in [the CI workflow](../.github/workflows/ci.yml).
+Document whether validation was offline or used a live model; offline parser
+and evidence checks do not establish judge accuracy on a real dataset.


### PR DESCRIPTION
## Related work

Documentation follow-up to #21 and #26, and merged PRs #37, #58, #61, #64, and #65.

## What changed

The README omits three shipped retrieval scorers from its judge-scorer list and does not explain that `CallableModel` leaves provider message construction and context trust boundaries to the caller. Update the list and document the forwarding contract, metadata behavior, and conditions needed to interpret comparisons with built-in adapters.

Add a scorer-authoring guide grounded in current `main`: assessed versus unassessed results, validated evidence, input forwarding, retrieval denominators, async behavior, registration, and offline verification. Keep the unmerged citation scorer explicitly outside the supported API described by the guide. Add permanent acknowledgments for 16 contributors, with links to their merged work, and narrowly allow the documentation paths in the publish allowlist.

## Validation

- Executed the scorer guide's Python example and checked measured pass, measured failure, missing-reference, and invalid-reference cases.
- Checked every local Markdown link target in the changed documents and verified every scorer named in the README list exists in `rai_toolkit.scorers.llm_judges`.
- Verified contributor handles and the associated merged work against the GitHub commit history through September 12, 2026.
- `python -m ruff check --select E9,F63,F7,F82 .`: passed.
- `reuse --no-multiprocessing lint`: passed for all 133 files.
- `git diff --cached --check`: passed.
- No runtime behavior changes. No additional runtime tests were added; the new documentation example was executed offline.

## AI assistance

Prepared with AI assistance. Documentation claims were checked against current source, the new example was executed, and contributor attributions were verified against merged GitHub history.
